### PR TITLE
ci: warn on long commit body line

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -4,6 +4,7 @@ const Configuration= {
     rules: {
         'body-empty': [1, 'never'],
         'body-case': [2, 'always', 'sentence-case'],
+        'body-max-line-length': [1, 'always', 100],
         'references-empty': [1, 'never'],
         'signed-off-by': [2, 'always', 'Signed-off-by:'],
     },


### PR DESCRIPTION
Avoid failing the commitlint task on long commit body lines and just raise a warning. This allows renovate tabled commit messages to pass the ci.