### PR TITLE
chore: limit renovate PRs and rebases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,8 @@
     ":automergeMinor",
     ":automergeDigest"
   ],
+  rebaseWhen: 'never',
+  prConcurrentLimit: 5,
   "gomod": {
     // Do not manage the dagger go.mod file
     "ignorePaths": ["dagger/gotest/go.mod"],


### PR DESCRIPTION
Limit the amount of PRs opened by renovate and also do not
auto rebase the PRs to avoid consuming all the GitHub Runners