### PR TITLE
test(e2e): enable GCS tests with fake-gcs-server

### DIFF
--- a/test/e2e/internal/objectstore/fakegcsserver.go
+++ b/test/e2e/internal/objectstore/fakegcsserver.go
@@ -67,8 +67,9 @@ func newGCSDeployment(namespace, name string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name: name,
-							// TODO: renovate the image
-							Image: "registry.barman-cloud-plugin:5000/fakegcs:test",
+							// TODO: use the official image when https://github.com/fsouza/fake-gcs-server/pull/1827
+							//   is merged and released
+							Image: "ghcr.io/fcanovai/fake-gcs-server:latest",
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 4443,
@@ -189,7 +190,14 @@ func NewGCSObjectStore(namespace, name, gcsOSName string) *pluginBarmanCloudV1.O
 					},
 				},
 				DestinationPath: "gs://backups/",
-				EndpointURL:     fmt.Sprintf("http://%v:4443", gcsOSName),
+			},
+			InstanceSidecarConfiguration: pluginBarmanCloudV1.InstanceSidecarConfiguration{
+				Env: []corev1.EnvVar{
+					{
+						Name:  "STORAGE_EMULATOR_HOST",
+						Value: fmt.Sprintf("http://%v:4443", gcsOSName),
+					},
+				},
 			},
 		},
 	}

--- a/test/e2e/internal/tests/backup/backup_restore.go
+++ b/test/e2e/internal/tests/backup/backup_restore.go
@@ -195,15 +195,13 @@ var _ = Describe("Backup and restore", func() {
 			"using in-tree for backup and the plugin for restore on Azure",
 			&azureBackupPluginInTreeBackupPluginRestore{},
 		),
-		// TODO: enable the tests for GCS when we have support for STORAGE_EMULATOR_HOST
-		//   env variable.
-		PEntry("using the plugin for backup and restore on GCS",
+		Entry("using the plugin for backup and restore on GCS",
 			&gcsBackupPluginBackupPluginRestore{},
 		),
-		PEntry("using the plugin for backup and in-tree for restore on GCS",
+		Entry("using the plugin for backup and in-tree for restore on GCS",
 			&gcsBackupPluginBackupInTreeRestore{},
 		),
-		PEntry(
+		Entry(
 			"using in-tree for backup and the plugin for restore on GCS",
 			&gcsBackupPluginInTreeBackupPluginRestore{},
 		),

--- a/test/e2e/internal/tests/backup/fixtures.go
+++ b/test/e2e/internal/tests/backup/fixtures.go
@@ -579,6 +579,12 @@ func newSrcClusterInTreeGCS(namespace string) *cloudnativepgv1.Cluster {
 			StorageConfiguration: cloudnativepgv1.StorageConfiguration{
 				Size: size,
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "STORAGE_EMULATOR_HOST",
+					Value: fmt.Sprintf("http://%v:4443", gcs),
+				},
+			},
 			Backup: &cloudnativepgv1.BackupConfiguration{
 				BarmanObjectStore: &cloudnativepgv1.BarmanObjectStoreConfiguration{
 					BarmanCredentials: barmanapi.BarmanCredentials{
@@ -591,7 +597,6 @@ func newSrcClusterInTreeGCS(namespace string) *cloudnativepgv1.Cluster {
 							},
 						},
 					},
-					EndpointURL:     fmt.Sprintf("http://%v:4443", gcs),
 					DestinationPath: "gs://backups/",
 				},
 			},
@@ -627,6 +632,12 @@ func newDstClusterInTreeGCS(namespace string) *cloudnativepgv1.Cluster {
 					},
 				},
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "STORAGE_EMULATOR_HOST",
+					Value: fmt.Sprintf("http://%v:4443", gcs),
+				},
+			},
 			ExternalClusters: []cloudnativepgv1.ExternalCluster{
 				{
 					Name: "source",
@@ -642,7 +653,6 @@ func newDstClusterInTreeGCS(namespace string) *cloudnativepgv1.Cluster {
 							},
 						},
 						DestinationPath: "gs://backups/",
-						EndpointURL:     fmt.Sprintf("http://%v:4443", gcs),
 					},
 				},
 			},


### PR DESCRIPTION
Activate backup and restore tests with GCS using the fake-gcs-server emulator. Use a fork that support partial reads.