### PR TITLE
ci: use linter cache

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,6 +16,9 @@ tasks:
     cmds:
       - >
         GITHUB_REF= dagger -s call -m github.com/sagikazarmark/daggerverse/golangci-lint@${DAGGER_GOLANGCI_LINT_SHA}
+        with-linter-cache --cache golangci-lint
+        with-build-cache --cache go-build
+        with-module-cache --cache go-mod
         run --source . --config .golangci.yml stdout
     sources:
       - ./**/*.go

--- a/containers/Dockerfile.plugin
+++ b/containers/Dockerfile.plugin
@@ -16,6 +16,9 @@ COPY ../cmd/manager/main.go cmd/manager/main.go
 COPY ../api/ api/
 COPY ../internal/ internal/
 
+ENV GOCACHE=/root/.cache/go-build
+ENV GOMODCACHE=/go/pkg/mod
+
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO

--- a/containers/Dockerfile.sidecar
+++ b/containers/Dockerfile.sidecar
@@ -17,6 +17,9 @@ COPY ../go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+ENV GOCACHE=/root/.cache/go-build
+ENV GOMODCACHE=/go/pkg/mod
+
 # Copy the go source
 COPY ../cmd/manager/main.go cmd/manager/main.go
 COPY ../api/ api/


### PR DESCRIPTION
Improve cache usage for faster local ci runs.