### PR TITLE
chore: graceful startup probe

### DIFF
--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -312,7 +312,8 @@ func reconcilePodSpec(
 	envs = append(envs, additionalEnvs...)
 
 	baseProbe := &corev1.Probe{
-		FailureThreshold: 3,
+		FailureThreshold: 10,
+		TimeoutSeconds:   10,
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"/manager", "healthcheck", "unix"},
@@ -324,7 +325,6 @@ func reconcilePodSpec(
 	sidecarConfig.Name = "plugin-barman-cloud"
 	sidecarConfig.Image = viper.GetString("sidecar-image")
 	sidecarConfig.ImagePullPolicy = cluster.Spec.ImagePullPolicy
-	sidecarConfig.LivenessProbe = baseProbe.DeepCopy()
 	sidecarConfig.StartupProbe = baseProbe.DeepCopy()
 
 	// merge the main container envs if they aren't already set

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -796,7 +796,8 @@ spec:
   selector:
     matchLabels:
       app: barman-cloud
-  strategy: {}
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/test/e2e/internal/tests/backup/backup_restore.go
+++ b/test/e2e/internal/tests/backup/backup_restore.go
@@ -75,7 +75,7 @@ var _ = Describe("Backup and restore", func() {
 					},
 					src)).To(Succeed())
 				g.Expect(cluster2.IsReady(*src)).To(BeTrue())
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 			By("Adding data to PostgreSQL")
 			clientSet, cfg, err := internalClient.NewClientSet()
@@ -144,7 +144,7 @@ var _ = Describe("Backup and restore", func() {
 					types.NamespacedName{Name: dst.Name, Namespace: dst.Namespace},
 					dst)).To(Succeed())
 				g.Expect(cluster2.IsReady(*dst)).To(BeTrue())
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 			By("Verifying the data exists in the restored instance")
 			output, _, err := command.ExecuteInContainer(ctx,

--- a/test/e2e/internal/tests/replicacluster/replica_cluster.go
+++ b/test/e2e/internal/tests/replicacluster/replica_cluster.go
@@ -123,7 +123,7 @@ var _ = Describe("Replica cluster", func() {
 					},
 					replica)).To(Succeed())
 				g.Expect(cluster2.IsReady(*replica)).To(BeTrue())
-			}).WithTimeout(5 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+			}).WithTimeout(15 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
 
 			By("Checking the data in the replica cluster")
 			output, _, err := command.ExecuteInContainer(ctx,


### PR DESCRIPTION
Give more time to the startup probe to wait for the plugin to start, and remove the liveness probe for the instance plugin.