### PR TITLE
ci: add e2e kustomization.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ go.work
 
 # E2e test artifacts
 test/e2e/bin
+test/e2e/kustomization.yaml
+
 # Test registry certificates
 certs/
 # Utility dir for manifest build


### PR DESCRIPTION
Running e2e tests generates temporary kustomization.yaml files. The uncommitted ci task would fail if it finds one of these during its run, so we add the path to the .gitignore.

Fixes #111