### PR TITLE
feat: release-please cleanup

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,9 +39,6 @@ jobs:
           path: ./manifest.yaml
       # TODO: remove bump-minor-pre-major when in production. It prevents
       #   release-please from bumping the major version on breaking changes.
-      # TODO: remove release-as after first release. Used to set the first
-      #   release version, which would default to 1.0.0. Set the version
-      #   manually also for 1.0.0.
       # We use a GitHub token with write permissions to create the release,
       # otherwise we won't be able to trigger a new run when pushing on main.
       - name: Run release-please

--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ Both checks are necessary to proceed with the installation.
 
 Use `kubectl` to apply the manifest for the latest commit in the `main` branch:
 
+<!-- x-release-please-start-version -->
 ```sh
 kubectl apply -f \
   https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.1.0/manifest.yaml
 ```
+<!-- x-release-please-end -->
 
 Example output:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,12 +4,14 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
+  "extra-files": [
+    "README.md"
+  ],
   "prerelease": false,
   "packages": {
     ".": {}
   },
   "plugins": [ "sentence-case" ],
-  "release-as": "0.1.0",
   "signoff": "Peggie <info@cloudnative-pg.io>",
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
Stop forcing the initial version to 0.1.0, to allow for release-please version updates. Also, automate the update of the README on release.

Closes #114 