### PR TITLE
chore: group sagikazarmark/daggerverse deps in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -65,6 +65,18 @@
       "groupName": "all cloudnative-pg daggerverse dependencies"
     },
     {
+      "matchDatasources": [
+        "git-refs"
+      ],
+      "matchPackageNames": [
+        "https://github.com/sagikazarmark/daggerverse"
+      ],
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "groupName": "all sagikazarmark daggerverse dependencies"
+    },
+    {
       "matchUpdateTypes": [
         "minor",
         "patch"


### PR DESCRIPTION
Group all the dagger modules coming from the sagikazarmark/daggerverse repo in a single renovate PR. This prevents single commits in that repo to cause multiple PRs in this one.

Closes #118