### PR TITLE
test: use minimal image for testing

### DIFF
--- a/test/e2e/internal/tests/backup/fixtures.go
+++ b/test/e2e/internal/tests/backup/fixtures.go
@@ -285,6 +285,7 @@ func newSrcClusterWithPlugin(namespace string) *cloudnativepgv1.Cluster {
 		Spec: cloudnativepgv1.ClusterSpec{
 			Instances:       2,
 			ImagePullPolicy: corev1.PullAlways,
+			ImageName:       "ghcr.io/cloudnative-pg/postgresql:17-minimal-bookworm",
 			Plugins: []cloudnativepgv1.PluginConfiguration{
 				{
 					Name: "barman-cloud.cloudnative-pg.io",
@@ -320,6 +321,7 @@ func newDstClusterWithPlugin(namespace string) *cloudnativepgv1.Cluster {
 		Spec: cloudnativepgv1.ClusterSpec{
 			Instances:       2,
 			ImagePullPolicy: corev1.PullAlways,
+			ImageName:       "ghcr.io/cloudnative-pg/postgresql:17-minimal-bookworm",
 			Bootstrap: &cloudnativepgv1.BootstrapConfiguration{
 				Recovery: &cloudnativepgv1.BootstrapRecovery{
 					Source: "source",

--- a/test/e2e/internal/tests/replicacluster/fixtures.go
+++ b/test/e2e/internal/tests/replicacluster/fixtures.go
@@ -112,6 +112,7 @@ func newSrcCluster(namespace string) *cloudnativepgv1.Cluster {
 		Spec: cloudnativepgv1.ClusterSpec{
 			Instances:       2,
 			ImagePullPolicy: corev1.PullAlways,
+			ImageName:       "ghcr.io/cloudnative-pg/postgresql:17-minimal-bookworm",
 			Plugins: []cloudnativepgv1.PluginConfiguration{
 				{
 					Name: "barman-cloud.cloudnative-pg.io",
@@ -218,6 +219,7 @@ func newReplicaCluster(namespace string) *cloudnativepgv1.Cluster {
 		Spec: cloudnativepgv1.ClusterSpec{
 			Instances:       2,
 			ImagePullPolicy: corev1.PullAlways,
+			ImageName:       "ghcr.io/cloudnative-pg/postgresql:17-minimal-bookworm",
 			Bootstrap: &cloudnativepgv1.BootstrapConfiguration{
 				Recovery: &cloudnativepgv1.BootstrapRecovery{
 					Source: "source",


### PR DESCRIPTION
Use 17-minimal-bookworm images instead of default ones for all the tests, except the one where we need barman cloud to check compatibility.

Supersedes #134 