### PR TITLE
feat: support custom CA certificates

### DIFF
--- a/docs/examples/minio-store.yaml
+++ b/docs/examples/minio-store.yaml
@@ -4,8 +4,11 @@ metadata:
   name: minio-store
 spec:
   configuration:
+    endpointCA:
+      name: minio-server-tls
+      key: tls.crt
     destinationPath: s3://backups/
-    endpointURL: http://minio:9000
+    endpointURL: https://minio:9000
     s3Credentials:
       accessKeyId:
         name: minio

--- a/go.mod
+++ b/go.mod
@@ -136,3 +136,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/cloudnative-pg/barman-cloud => github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ toolchain go1.24.1
 require (
 	github.com/cert-manager/cert-manager v1.17.1
 	github.com/cloudnative-pg/api v1.25.1
-	github.com/cloudnative-pg/barman-cloud v0.1.0
+	github.com/cloudnative-pg/barman-cloud v0.2.0
 	github.com/cloudnative-pg/cloudnative-pg v1.25.1
 	github.com/cloudnative-pg/cnpg-i v0.1.0
 	github.com/cloudnative-pg/cnpg-i-machinery v0.1.2
 	github.com/cloudnative-pg/machinery v0.1.0
-	github.com/onsi/ginkgo/v2 v2.22.2
+	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
@@ -118,7 +118,7 @@ require (
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
-	golang.org/x/tools v0.28.0 // indirect
+	golang.org/x/tools v0.30.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
@@ -136,5 +136,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/cloudnative-pg/barman-cloud => github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.25.1 h1:uNjKiB0MIspUeH9l651SnFDcuflr1crB3t6LjxUCafQ=
 github.com/cloudnative-pg/api v1.25.1/go.mod h1:fwF5g4XkuNZqYXIeRR3AJvUfWlqWig+r2DXc5bEmw6U=
-github.com/cloudnative-pg/barman-cloud v0.1.0 h1:e/z52CehMBIh1LjZqNBJnncWJbS+1JYvRMBR8Js6Uiw=
-github.com/cloudnative-pg/barman-cloud v0.1.0/go.mod h1:rJUJO/f1yNckLZiVxHAyRmKY+4EPJkYRJsGbTZRJQSY=
 github.com/cloudnative-pg/cloudnative-pg v1.25.1 h1:Yc6T7ikQ1AiWXBQht+6C3DoihrIpUN2OkM1dIwqadTo=
 github.com/cloudnative-pg/cloudnative-pg v1.25.1/go.mod h1:96b9bRFLSr3uFWHjhytPdcvKIKwy9H6AG7cH0O6jefs=
 github.com/cloudnative-pg/cnpg-i v0.1.0 h1:QH2xTsrODMhEEc6B25GbOYe7ZIttDmSkYvXotfU5dfs=
@@ -116,6 +114,8 @@ github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0 h1:Q3jQ1NkFqv5o+
 github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0/go.mod h1:E3vdYxHj2C2q6qo8/Da4g7P+IcwqRZyy3gJBzYybV9Y=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111 h1:opN3VCteYluh6R1OUvt1AU5SuiBdYa4ZzrMf0prRHXk=
+github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111/go.mod h1:rJUJO/f1yNckLZiVxHAyRmKY+4EPJkYRJsGbTZRJQSY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.25.1 h1:uNjKiB0MIspUeH9l651SnFDcuflr1crB3t6LjxUCafQ=
 github.com/cloudnative-pg/api v1.25.1/go.mod h1:fwF5g4XkuNZqYXIeRR3AJvUfWlqWig+r2DXc5bEmw6U=
+github.com/cloudnative-pg/barman-cloud v0.2.0 h1:KMwJPKjytDqljNNOounBGojsGTXiowztH0WQrVB8/DQ=
+github.com/cloudnative-pg/barman-cloud v0.2.0/go.mod h1:kNIUU+fpnYjkr25YwHnteROLhbs6rqpjDiB8XW1+sug=
 github.com/cloudnative-pg/cloudnative-pg v1.25.1 h1:Yc6T7ikQ1AiWXBQht+6C3DoihrIpUN2OkM1dIwqadTo=
 github.com/cloudnative-pg/cloudnative-pg v1.25.1/go.mod h1:96b9bRFLSr3uFWHjhytPdcvKIKwy9H6AG7cH0O6jefs=
 github.com/cloudnative-pg/cnpg-i v0.1.0 h1:QH2xTsrODMhEEc6B25GbOYe7ZIttDmSkYvXotfU5dfs=
@@ -114,8 +116,6 @@ github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0 h1:Q3jQ1NkFqv5o+
 github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0/go.mod h1:E3vdYxHj2C2q6qo8/Da4g7P+IcwqRZyy3gJBzYybV9Y=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111 h1:opN3VCteYluh6R1OUvt1AU5SuiBdYa4ZzrMf0prRHXk=
-github.com/leonardoce/barman-cloud v0.0.0-20250310163530-1a3fac818111/go.mod h1:rJUJO/f1yNckLZiVxHAyRmKY+4EPJkYRJsGbTZRJQSY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
@@ -137,8 +137,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
-github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
+github.com/onsi/ginkgo/v2 v2.23.0 h1:FA1xjp8ieYDzlgS5ABTpdUDB7wtngggONc8a7ku2NqQ=
+github.com/onsi/ginkgo/v2 v2.23.0/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
@@ -271,8 +271,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.28.0 h1:WuB6qZ4RPCQo5aP3WdKZS7i595EdWqWR8vqJTlwTVK8=
-golang.org/x/tools v0.28.0/go.mod h1:dcIOrVd3mfQKTgrDVQHqCPMWy6lnhfhtX3hLXYVLfRw=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/cnpgi/common/common.go
+++ b/internal/cnpgi/common/common.go
@@ -2,9 +2,12 @@ package common
 
 import (
 	"fmt"
+	"path"
 	"strings"
 
 	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
 )
 
 // TODO: refactor.
@@ -69,4 +72,9 @@ func MergeEnv(env []string, incomingEnv []string) []string {
 	}
 
 	return result
+}
+
+// BuildCertificateFilePath builds the path to the barman objectStore certificate
+func BuildCertificateFilePath(objectStoreName string) string {
+	return path.Join(metadata.BarmanCertificatesPath, objectStoreName, metadata.BarmanCertificatesFileName)
 }

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -83,7 +83,7 @@ func (w WALServiceImplementation) Archive(
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
 		os.Environ(),
-		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
+		BuildCertificateFilePath(objectStore.Name),
 	)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
@@ -199,7 +199,7 @@ func (w WALServiceImplementation) restoreFromBarmanObjectStore(
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
 		os.Environ(),
-		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
+		BuildCertificateFilePath(objectStore.Name),
 	)
 	if err != nil {
 		return fmt.Errorf("while getting recover credentials: %w", err)

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -77,12 +77,14 @@ func (w WALServiceImplementation) Archive(
 		return nil, err
 	}
 
-	envArchive, err := barmanCredentials.EnvSetBackupCloudCredentials(
+	envArchive, err := barmanCredentials.EnvSetCloudCredentialsAndCertificates(
 		ctx,
 		w.Client,
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
-		os.Environ())
+		os.Environ(),
+		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
+	)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
 			return nil, errors.New("backup credentials don't yet have access permissions. Will retry reconciliation loop")
@@ -191,12 +193,13 @@ func (w WALServiceImplementation) restoreFromBarmanObjectStore(
 	barmanConfiguration := &objectStore.Spec.Configuration
 
 	env := GetRestoreCABundleEnv(barmanConfiguration)
-	credentialsEnv, err := barmanCredentials.EnvSetBackupCloudCredentials(
+	credentialsEnv, err := barmanCredentials.EnvSetCloudCredentialsAndCertificates(
 		ctx,
 		w.Client,
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
 		os.Environ(),
+		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
 	)
 	if err != nil {
 		return fmt.Errorf("while getting recover credentials: %w", err)

--- a/internal/cnpgi/instance/backup.go
+++ b/internal/cnpgi/instance/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -98,12 +99,14 @@ func (b BackupServiceImplementation) Backup(
 	// PGHOST (and the like) to be available
 	osEnvironment := os.Environ()
 	caBundleEnvironment := common.GetRestoreCABundleEnv(&objectStore.Spec.Configuration)
-	env, err := barmanCredentials.EnvSetBackupCloudCredentials(
+	env, err := barmanCredentials.EnvSetCloudCredentialsAndCertificates(
 		ctx,
 		b.Client,
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
-		common.MergeEnv(osEnvironment, caBundleEnvironment))
+		common.MergeEnv(osEnvironment, caBundleEnvironment),
+		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
+	)
 	if err != nil {
 		contextLogger.Error(err, "while setting backup cloud credentials")
 		return nil, err

--- a/internal/cnpgi/instance/backup.go
+++ b/internal/cnpgi/instance/backup.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 	"time"
 
@@ -105,7 +104,7 @@ func (b BackupServiceImplementation) Backup(
 		objectStore.Namespace,
 		&objectStore.Spec.Configuration,
 		common.MergeEnv(osEnvironment, caBundleEnvironment),
-		path.Join(metadata.BarmanCertificatesPath, objectStore.Name, metadata.BarmanCertificatesFileName),
+		common.BuildCertificateFilePath(objectStore.Name),
 	)
 	if err != nil {
 		contextLogger.Error(err, "while setting backup cloud credentials")

--- a/internal/cnpgi/metadata/constants.go
+++ b/internal/cnpgi/metadata/constants.go
@@ -11,6 +11,14 @@ const (
 	// if present, requires the WAL archiver to check that the backup object
 	// store is empty.
 	CheckEmptyWalArchiveFile = ".check-empty-wal-archive"
+
+	// BarmanCertificatesPath is the path where the Barman
+	// certificates will be installed
+	BarmanCertificatesPath = "/barman-certificates"
+
+	// BarmanCertificatesFileName is the path where the Barman
+	// certificates will be used
+	BarmanCertificatesFileName = "barman-ca.crt"
 )
 
 // Data is the metadata of this plugin.

--- a/internal/cnpgi/operator/lifecycle_certificates.go
+++ b/internal/cnpgi/operator/lifecycle_certificates.go
@@ -1,0 +1,89 @@
+package operator
+
+import (
+	"context"
+	"path"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/operator/config"
+)
+
+// barmanCertificatesVolumeName is the name of the volume that hosts
+// the barman certificates to be used
+const barmanCertificatesVolumeName = "barman-certificates"
+
+func (impl LifecycleImplementation) collectAdditionalCertificates(
+	ctx context.Context,
+	namespace string,
+	pluginConfiguration *config.PluginConfiguration,
+) ([]corev1.VolumeProjection, error) {
+	var result []corev1.VolumeProjection
+
+	if len(pluginConfiguration.BarmanObjectName) > 0 {
+		envs, err := impl.collectObjectStoreCertificates(
+			ctx,
+			types.NamespacedName{
+				Name:      pluginConfiguration.BarmanObjectName,
+				Namespace: namespace,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, envs...)
+	}
+
+	if len(pluginConfiguration.RecoveryBarmanObjectName) > 0 {
+		envs, err := impl.collectObjectStoreCertificates(
+			ctx,
+			types.NamespacedName{
+				Name:      pluginConfiguration.RecoveryBarmanObjectName,
+				Namespace: namespace,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, envs...)
+	}
+
+	return result, nil
+}
+
+func (impl LifecycleImplementation) collectObjectStoreCertificates(
+	ctx context.Context,
+	barmanObjectKey types.NamespacedName,
+) ([]corev1.VolumeProjection, error) {
+	var objectStore barmancloudv1.ObjectStore
+	if err := impl.Client.Get(ctx, barmanObjectKey, &objectStore); err != nil {
+		return nil, err
+	}
+
+	endpointCA := objectStore.Spec.Configuration.EndpointCA
+	if endpointCA == nil {
+		return nil, nil
+	}
+
+	return []corev1.VolumeProjection{
+		{
+			Secret: &corev1.SecretProjection{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: endpointCA.Name,
+				},
+				Items: []corev1.KeyToPath{
+					{
+						Key: endpointCA.Key,
+						Path: path.Join(
+							barmanObjectKey.Name,
+							metadata.BarmanCertificatesFileName,
+						),
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/cnpgi/operator/lifecycle_envs.go
+++ b/internal/cnpgi/operator/lifecycle_envs.go
@@ -1,0 +1,61 @@
+package operator
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/operator/config"
+)
+
+func (impl LifecycleImplementation) collectAdditionalEnvs(
+	ctx context.Context,
+	namespace string,
+	pluginConfiguration *config.PluginConfiguration,
+) ([]corev1.EnvVar, error) {
+	var result []corev1.EnvVar
+
+	if len(pluginConfiguration.BarmanObjectName) > 0 {
+		envs, err := impl.collectObjectStoreEnvs(
+			ctx,
+			types.NamespacedName{
+				Name:      pluginConfiguration.BarmanObjectName,
+				Namespace: namespace,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, envs...)
+	}
+
+	if len(pluginConfiguration.RecoveryBarmanObjectName) > 0 {
+		envs, err := impl.collectObjectStoreEnvs(
+			ctx,
+			types.NamespacedName{
+				Name:      pluginConfiguration.RecoveryBarmanObjectName,
+				Namespace: namespace,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, envs...)
+	}
+
+	return result, nil
+}
+
+func (impl LifecycleImplementation) collectObjectStoreEnvs(
+	ctx context.Context,
+	barmanObjectKey types.NamespacedName,
+) ([]corev1.EnvVar, error) {
+	var objectStore barmancloudv1.ObjectStore
+	if err := impl.Client.Get(ctx, barmanObjectKey, &objectStore); err != nil {
+		return nil, err
+	}
+
+	return objectStore.Spec.InstanceSidecarConfiguration.Env, nil
+}

--- a/internal/cnpgi/operator/lifecycle_test.go
+++ b/internal/cnpgi/operator/lifecycle_test.go
@@ -107,7 +107,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				ObjectDefinition: jobJSON,
 			}
 
-			response, err := reconcileJob(ctx, cluster, request, nil)
+			response, err := reconcileJob(ctx, cluster, request, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(response).NotTo(BeNil())
 			Expect(response.JsonPatch).NotTo(BeEmpty())
@@ -128,7 +128,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				ObjectDefinition: jobJSON,
 			}
 
-			response, err := reconcileJob(ctx, cluster, request, nil)
+			response, err := reconcileJob(ctx, cluster, request, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(response).To(BeNil())
 		})
@@ -138,7 +138,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				ObjectDefinition: []byte("invalid-json"),
 			}
 
-			response, err := reconcileJob(ctx, cluster, request, nil)
+			response, err := reconcileJob(ctx, cluster, request, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(response).To(BeNil())
 		})
@@ -165,7 +165,7 @@ var _ = Describe("LifecycleImplementation", func() {
 					ObjectDefinition: jobJSON,
 				}
 
-				response, err := reconcileJob(ctx, cluster, request, nil)
+				response, err := reconcileJob(ctx, cluster, request, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(response).To(BeNil())
 			})
@@ -185,7 +185,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				ObjectDefinition: podJSON,
 			}
 
-			response, err := reconcilePod(ctx, cluster, request, pluginConfiguration, nil)
+			response, err := reconcilePod(ctx, cluster, request, pluginConfiguration, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(response).NotTo(BeNil())
 			Expect(response.JsonPatch).NotTo(BeEmpty())
@@ -203,7 +203,7 @@ var _ = Describe("LifecycleImplementation", func() {
 				ObjectDefinition: []byte("invalid-json"),
 			}
 
-			response, err := reconcilePod(ctx, cluster, request, pluginConfiguration, nil)
+			response, err := reconcilePod(ctx, cluster, request, pluginConfiguration, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(response).To(BeNil())
 		})

--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/common"
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/operator/config"
 )
@@ -234,7 +235,7 @@ func (impl *JobHookImpl) checkBackupDestination(
 		cluster.Namespace,
 		barmanConfiguration,
 		os.Environ(),
-		path.Join(metadata.BarmanCertificatesPath, objectStoreName, metadata.BarmanCertificatesFileName),
+		common.BuildCertificateFilePath(objectStoreName),
 	)
 	if err != nil {
 		return fmt.Errorf("can't get credentials for cluster %v: %w", cluster.Name, err)
@@ -353,7 +354,7 @@ func loadBackupObjectFromExternalCluster(
 		cluster.Namespace,
 		recoveryObjectStore,
 		os.Environ(),
-		path.Join(metadata.BarmanCertificatesPath, recoveryObjectStoreName, metadata.BarmanCertificatesFileName))
+		common.BuildCertificateFilePath(recoveryObjectStoreName))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This patch enables the use of custom CA certificates when connecting to the object store in the barman-cloud plugin. The certificates are injected into the sidecar via a projected volume and used by the barman-cloud tool suite.

If the barman object name or the key name changes, users must trigger a Pod rollout to apply the new values.