### PR TITLE
feat: upgrade Barman to 3.13.0

### DIFF
--- a/containers/sidecar-requirements.in
+++ b/containers/sidecar-requirements.in
@@ -1,3 +1,3 @@
-barman[azure,cloud,google,snappy,zstandard,lz4]==3.12.1
+barman[azure,cloud,google,snappy,zstandard,lz4]==3.13.0
 setuptools==75.8.2
 boto3==1.35.99

--- a/containers/sidecar-requirements.txt
+++ b/containers/sidecar-requirements.txt
@@ -18,9 +18,9 @@ azure-storage-blob==12.24.1 \
     --hash=sha256:052b2a1ea41725ba12e2f4f17be85a54df1129e13ea0321f5a2fcc851cbf47d4 \
     --hash=sha256:77fb823fdbac7f3c11f7d86a5892e2f85e161e8440a7489babe2195bf248f09e
     # via barman
-barman==3.12.1 \
-    --hash=sha256:258ef7100717f66032402e0abe03c977089c50fc47143df5708e92aa1d772937 \
-    --hash=sha256:9dd7be219b6f74954b80cdc28f9a72f2acb923e7da65edd0f41cdc82fd32e169
+barman==3.13.0 \
+    --hash=sha256:4c040d65f80dcd69876063781524ffa4f7918969d98b461eb43123ac5f96f260 \
+    --hash=sha256:b2ff8af2bacc6958efeec23fa26295f035658ab55d815d7f3c583cef1d8bfdfe
     # via -r sidecar-requirements.in
 boto3==1.35.99 \
     --hash=sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71 \

--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -153,18 +153,17 @@ func (impl JobHookImpl) restoreDataDir(
 ) error {
 	var options []string
 
+	options, err := barmanCommand.AppendCloudProviderOptionsFromConfiguration(ctx, options, barmanConfiguration)
+	if err != nil {
+		return err
+	}
+
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
 	}
 	options = append(options, backup.Status.DestinationPath)
 	options = append(options, backup.Status.ServerName)
 	options = append(options, backup.Status.BackupID)
-
-	options, err := barmanCommand.AppendCloudProviderOptionsFromConfiguration(ctx, options, barmanConfiguration)
-	if err != nil {
-		return err
-	}
-
 	options = append(options, impl.PgDataPath)
 
 	log.Info("Starting barman-cloud-restore",


### PR DESCRIPTION
Upgrade Barman to 3.13.0 and adjust the argument order in `barman-cloud-restore` to work around the regression described in cloudnative-pg/cloudnative-pg#6932.

Closes #208