### PR TITLE
feat: implement evaluate lifecycle hook

### DIFF
--- a/docs/examples/cluster-example-legacy.yaml
+++ b/docs/examples/cluster-example-legacy.yaml
@@ -4,12 +4,14 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  imagePullPolicy: Always
 
   backup:
     barmanObjectStore:
+      endpointCA:
+        name: minio-server-tls
+        key: tls.crt
       destinationPath: s3://backups/
-      endpointURL: http://minio:9000
+      endpointURL: https://minio:9000
       s3Credentials:
         accessKeyId:
           name: minio

--- a/docs/examples/cluster-example.yaml
+++ b/docs/examples/cluster-example.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  imagePullPolicy: Always
   plugins:
   - name: barman-cloud.cloudnative-pg.io
     isWALArchiver: true

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cloudnative-pg/api v1.25.1
 	github.com/cloudnative-pg/barman-cloud v0.3.0
 	github.com/cloudnative-pg/cloudnative-pg v1.25.1
-	github.com/cloudnative-pg/cnpg-i v0.1.0
+	github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb
 	github.com/cloudnative-pg/cnpg-i-machinery v0.2.0
 	github.com/cloudnative-pg/machinery v0.1.0
 	github.com/onsi/ginkgo/v2 v2.23.1

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/cloudnative-pg/cloudnative-pg v1.25.1 h1:Yc6T7ikQ1AiWXBQht+6C3DoihrIp
 github.com/cloudnative-pg/cloudnative-pg v1.25.1/go.mod h1:96b9bRFLSr3uFWHjhytPdcvKIKwy9H6AG7cH0O6jefs=
 github.com/cloudnative-pg/cnpg-i v0.1.0 h1:QH2xTsrODMhEEc6B25GbOYe7ZIttDmSkYvXotfU5dfs=
 github.com/cloudnative-pg/cnpg-i v0.1.0/go.mod h1:G28BhgUEHqrxEyyQeHz8BbpMVAsGuLhJm/tHUbDi8Sw=
+github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb h1:FPORwCxjZwlnKnF7dOkuOAz0GBSQ3Hrn+8lm4uMiWeM=
+github.com/cloudnative-pg/cnpg-i v0.1.1-0.20250321093050-de4ab51537cb/go.mod h1:n+kbHm3rzRCY5IJKuE1tGMbG6JaeYz8yycYoLt7BeKo=
 github.com/cloudnative-pg/cnpg-i-machinery v0.2.0 h1:htNuKirdAOYrc7Hu5mLDoOES+nKSyPaXNDLgbV5dLSI=
 github.com/cloudnative-pg/cnpg-i-machinery v0.2.0/go.mod h1:MHVxMMbLeCRnEM8PLWW4C2CsHqOeAU2OsrwWMKy3tPA=
 github.com/cloudnative-pg/machinery v0.1.0 h1:tjRmsqQmsO/OlaT0uFmkEtVqgr+SGPM88cKZOHYKLBo=

--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -44,6 +44,9 @@ func (impl LifecycleImplementation) GetCapabilities(
 					{
 						Type: lifecycle.OperatorOperationType_TYPE_PATCH,
 					},
+					{
+						Type: lifecycle.OperatorOperationType_TYPE_EVALUATE,
+					},
 				},
 			},
 			{


### PR DESCRIPTION
This patch allows the plugin trigger a rolling deployment on existing clusters, enabling seamless migration between the in-tree barman cloud support and the plugin.

Closes #221 