### PR TITLE
chore: add word ordered task to CI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,8 +30,16 @@ tasks:
     sources:
       - ./**/*.go
 
+  wordlist-ordered:
+    desc: Order the word list file
+    cmds:
+      - LANG=C LC_ALL=C sort .wordlist.txt > .wordlist.txt.new
+      - mv -f .wordlist.txt.new .wordlist.txt
+
   spellcheck:
     desc: Run spellcheck
+    deps:
+      - wordlist-ordered
     env:
       # renovate: datasource=git-refs depName=spellcheck lookupName=https://github.com/cloudnative-pg/daggerverse currentValue=main
       DAGGER_SPELLCHECK_SHA: ba865842d907910c469d016c3ecfa009e4c66915

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,8 @@ tasks:
     cmds:
       - LANG=C LC_ALL=C sort .wordlist.txt > .wordlist.txt.new
       - mv -f .wordlist.txt.new .wordlist.txt
+    sources:
+      - .wordlist.txt
 
   spellcheck:
     desc: Run spellcheck
@@ -67,6 +69,7 @@ tasks:
     deps:
       - manifest-main
       - apidoc
+      - wordlist-ordered
     env:
       # renovate: datasource=git-refs depName=uncommitted lookupName=https://github.com/cloudnative-pg/daggerverse currentValue=main
       DAGGER_UNCOMMITTED_SHA: ba865842d907910c469d016c3ecfa009e4c66915


### PR DESCRIPTION
Added a word list ordered to the Taskfile to run as a dependency of the `spellcheck` task to keep the .wordlist.txt file in order

Closes #310 