### PR TITLE
chore: ignore go.mod inside dagger directory in renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,8 +14,7 @@
   "gomod": {
     // Do not manage the dagger go.mod file
     "ignorePaths": [
-      "dagger/gotest/go.mod",
-      "dagger/e2e/go.mod"
+      "dagger/**/go.mod",
     ]
   },
   "postUpdateOptions": [


### PR DESCRIPTION
We should ignore the go.mod files in renovate that are inside the dagger directory, these go.mod files should be updated using the proper `dagger update` command

Closes #305 