### PR TITLE
ci: fix setup-node action

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: latest
           check-latest: 'false'
           cache: yarn
-          cache-dependency-path: web/package-lock.json
+          cache-dependency-path: web/yarn.lock
 
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Fix the workflow to publish docs. It was trying to install npm dependencies when the documentation uses yarn.

Closes #324