### PR TITLE
ci(docs): allow workflow_dispatch for docs

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -3,6 +3,7 @@
 name: Deploy Docusaurus to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Maintainers can rebuild the development documentation using workflow dispatch, even when no changes have been made under 'web/docs/**' in main. in main.