### PR TITLE
fix(docs): remove "no downtime"

### DIFF
--- a/web/docs/migration.md
+++ b/web/docs/migration.md
@@ -11,7 +11,7 @@ from version 1.26** and will be removed in a future release.
 
 If you're currently relying on the built-in Barman Cloud integration, you can
 migrate seamlessly to the new **plugin-based architecture** using the Barman
-Cloud Plugin, with **no downtime**. Follow these steps:
+Cloud Plugin. Follow these steps:
 
 - [Install the Barman Cloud Plugin](installation.md)
 - Create an `ObjectStore` resource by translating the contents of the

--- a/web/docs/migration.md
+++ b/web/docs/migration.md
@@ -11,7 +11,7 @@ from version 1.26** and will be removed in a future release.
 
 If you're currently relying on the built-in Barman Cloud integration, you can
 migrate seamlessly to the new **plugin-based architecture** using the Barman
-Cloud Plugin. Follow these steps:
+Cloud Plugin, without data loss. Follow these steps:
 
 - [Install the Barman Cloud Plugin](installation.md)
 - Create an `ObjectStore` resource by translating the contents of the


### PR DESCRIPTION
cloeses #348

remove "no downtime"

The update of the Cluster from built-in to plugin based backup will tigger an rolling update, so there will be a downtime.

Signed-off-by: Daniel Chambre <smiyc@pm.me>