### PR TITLE
ci(publish): fix emulated arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
           echo "-------------Disk info after cleanup----------------"
           df -h
           echo "-----------------------------------------------------"
+      - uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
         # We need the full history for the commitlint task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,6 @@ jobs:
           df -h
           echo "-----------------------------------------------------"
       - uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
         # We need the full history for the commitlint task

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,14 @@ jobs:
           echo "-------------Disk info after cleanup----------------"
           df -h
           echo "-----------------------------------------------------"
-      - uses: docker/setup-qemu-action@v3
       - name: Checkout
         uses: actions/checkout@v4
         # We need the full history for the commitlint task
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v3
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Install Dagger

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,8 +16,6 @@ jobs:
         with:
           node-version: 20
       - uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Task

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,12 +12,14 @@ jobs:
       # TODO: googleapis/release-please-action cannot sign commits yet.
       #   We'll use the cli until there's a fix for
       #   https://github.com/googleapis/release-please/issues/2280.
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - uses: docker/setup-qemu-action@v3
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v3
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Install Dagger

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Task

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,6 +7,9 @@ jobs:
   release-publish-artifacts:
     runs-on: ubuntu-latest
     steps:
+      - uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Task

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Task

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,9 +7,10 @@ jobs:
   release-publish-artifacts:
     runs-on: ubuntu-latest
     steps:
-      - uses: docker/setup-qemu-action@v3
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v3
       - name: Install Task
         uses: arduino/setup-task@v2
       - name: Install Dagger


### PR DESCRIPTION
Use docker/setup-qemu-action to fix intermittent segmentation fault when building for arm64