### PR TITLE
feat(deps): update dependency barman to v3.14.0

### DIFF
--- a/containers/sidecar-requirements.txt
+++ b/containers/sidecar-requirements.txt
@@ -18,9 +18,9 @@ azure-storage-blob==12.25.1 \
     --hash=sha256:1f337aab12e918ec3f1b638baada97550673911c4ceed892acc8e4e891b74167 \
     --hash=sha256:4f294ddc9bc47909ac66b8934bd26b50d2000278b10ad82cc109764fdc6e0e3b
     # via barman
-barman==3.13.3 \
-    --hash=sha256:0ebc81caf4f9d8a9ca986d364a5cd6398ec90b5ef0292985e6551b8aba501114 \
-    --hash=sha256:d3fe573ea81d820ab0b30ec921c3ed2a226b8a1acdd9990a4bfdb84d3ff38906
+barman==3.14.0 \
+    --hash=sha256:372d5f1c13e4015c4335eb576a829562c350ba62bfca488d0677fabe8d104cb2 \
+    --hash=sha256:e99e4bb96e60d0efa20abeb3a5737cc02a6b4a91093dc43a284ccc2e4ee7749c
     # via -r sidecar-requirements.in
 boto3==1.38.24 \
     --hash=sha256:1f95ec3ac88ae6381fa0409e4c2ad0a41f0caf5fd6d8ef45a9525406a3f58b18 \


### PR DESCRIPTION
Due to an issue with pip-tools invocation, renovate has failed to update
Barman to 3.14.0 in #346. This patch fixes the issue.