### PR TITLE
chore(deps): really update dependency setuptools to v80.4.0

### DIFF
--- a/containers/sidecar-requirements.txt
+++ b/containers/sidecar-requirements.txt
@@ -683,7 +683,7 @@ zstandard==0.23.0 \
     # via barman
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==80.3.1 \
-    --hash=sha256:31e2c58dbb67c99c289f51c16d899afedae292b978f8051efaf6262d8212f927 \
-    --hash=sha256:ea8e00d7992054c4c592aeb892f6ad51fe1b4d90cc6947cc45c45717c40ec537
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
     # via -r sidecar-requirements.in


### PR DESCRIPTION
Due to an issue with pip-tools invocation, renovate has failed to update setuptools to v80.4.0 in #341. This patch fixes the issue.