### PR TITLE
ci: publish documentation if something changes

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
     paths:
-      - 'web/docs/**'
+      - 'web/**'
 
 # Prevent parallel deployments when multiple commits are pushed to main
 # in a short time.


### PR DESCRIPTION
With the previous settings, publishing occurred only when changes were made to the documentation pages. As a result, any new releases or modifications to dependencies that affected generated files would only be reflected after a manual run or an unrelated change in the documentation pages.