### PR TITLE
fix: remove lifecycle `Pod` `Patch` subscription

### DIFF
--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -42,9 +42,6 @@ func (impl LifecycleImplementation) GetCapabilities(
 						Type: lifecycle.OperatorOperationType_TYPE_CREATE,
 					},
 					{
-						Type: lifecycle.OperatorOperationType_TYPE_PATCH,
-					},
-					{
 						Type: lifecycle.OperatorOperationType_TYPE_EVALUATE,
 					},
 				},
@@ -92,15 +89,6 @@ func (impl LifecycleImplementation) LifecycleHook(
 	// barman object is required for both the archive and restore process
 	if err := pluginConfiguration.Validate(); err != nil {
 		contextLogger.Info("pluginConfiguration invalid, skipping lifecycle", "error", err)
-		return nil, nil
-	}
-
-	// Only allow modifications during EVALUATE or CREATE operations.
-	// For PATCH, UPDATE, or other operations, skip processing as the operator will handle changes during EVALUATE.
-	if *operation != lifecycle.OperatorOperationType_TYPE_EVALUATE &&
-		*operation != lifecycle.OperatorOperationType_TYPE_CREATE {
-		contextLogger.Trace("Skipping lifecycle hook: operation is not EVALUATE or CREATE",
-			"operation", operation.String())
 		return nil, nil
 	}
 

--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -95,6 +95,15 @@ func (impl LifecycleImplementation) LifecycleHook(
 		return nil, nil
 	}
 
+	// Only allow modifications during EVALUATE or CREATE operations.
+	// For PATCH, UPDATE, or other operations, skip processing as the operator will handle changes during EVALUATE.
+	if *operation != lifecycle.OperatorOperationType_TYPE_EVALUATE &&
+		*operation != lifecycle.OperatorOperationType_TYPE_CREATE {
+		contextLogger.Trace("Skipping lifecycle hook: operation is not EVALUATE or CREATE",
+			"operation", operation.String())
+		return nil, nil
+	}
+
 	switch kind {
 	case "Pod":
 		contextLogger.Info("Reconciling pod")


### PR DESCRIPTION
We cannot inject our sidecar during a PATCH call because Pods are mostly immutable. The combination of CREATE and EVALUATE is sufficient to instruct CNPG to roll out the pods if they need to update the sidecar.

Closes #377