### PR TITLE
chore: add pprof server to operator and sidecar

### DIFF
--- a/internal/cmd/instance/main.go
+++ b/internal/cmd/instance/main.go
@@ -40,6 +40,7 @@ func NewCmd() *cobra.Command {
 	_ = viper.BindEnv("spool-directory", "SPOOL_DIRECTORY")
 	_ = viper.BindEnv("custom-cnpg-group", "CUSTOM_CNPG_GROUP")
 	_ = viper.BindEnv("custom-cnpg-version", "CUSTOM_CNPG_VERSIONXS")
+	_ = viper.BindEnv("pprof-server", "PLUGIN_PPROF_SERVER")
 
 	return cmd
 }

--- a/internal/cmd/operator/main.go
+++ b/internal/cmd/operator/main.go
@@ -84,5 +84,7 @@ func NewCmd() *cobra.Command {
 
 	_ = viper.BindEnv("sidecar-image", "SIDECAR_IMAGE")
 
+	_ = viper.BindEnv("pprof-server", "PPROF_SERVER")
+
 	return cmd
 }

--- a/internal/cnpgi/instance/manager.go
+++ b/internal/cnpgi/instance/manager.go
@@ -44,6 +44,7 @@ func Start(ctx context.Context) error {
 				},
 			},
 		},
+		PprofBindAddress: viper.GetString("pprof-server"),
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), controllerOptions)

--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -332,7 +332,13 @@ func reconcilePodSpec(
 	}
 	sidecarTemplate.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
 	sidecarTemplate.Resources = config.resources
-
+	sidecarTemplate.Ports = []corev1.ContainerPort{
+		{
+			Name:          "pprof",
+			ContainerPort: 6061,
+			Protocol:      corev1.ProtocolTCP,
+		},
+	}
 	// merge the main container envs if they aren't already set
 	for _, container := range spec.Containers {
 		if container.Name == mainContainerName {

--- a/internal/cnpgi/operator/manager.go
+++ b/internal/cnpgi/operator/manager.go
@@ -104,6 +104,7 @@ func Start(ctx context.Context) error {
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: viper.GetString("health-probe-bind-address"),
+		PprofBindAddress:       viper.GetString("pprof-server"),
 		LeaderElection:         viper.GetBool("leader-elect"),
 		LeaderElectionID:       "822e3f5c.cnpg.io",
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        - containerPort: 6060
+          protocol: TCP
+          name: "pprof"
         env:
         - name: SIDECAR_IMAGE
           valueFrom:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -932,6 +932,9 @@ spec:
         ports:
         - containerPort: 9090
           protocol: TCP
+        - containerPort: 6060
+          name: pprof
+          protocol: TCP
         readinessProbe:
           initialDelaySeconds: 10
           periodSeconds: 10


### PR DESCRIPTION
We add the pprof server to the operator and the sidecar, to avoid any
conflict with the CloudNativePG operator and clusters we use the port 6061

Closes #421 