### PR TITLE
fix: missing permissions when OwnerReferencesPermissionEnforcement admission controller is enabled

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,9 +66,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - postgresql.cnpg.io
-  resources:
-  - clusters/finalizers
-  verbs:
-  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,3 +66,9 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters/finalizers
+  verbs:
+  - update

--- a/internal/controller/objectstore_controller.go
+++ b/internal/controller/objectstore_controller.go
@@ -39,6 +39,7 @@ type ObjectStoreReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=create;list;get;watch;delete
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=backups,verbs=get;list;watch
+// +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=barmancloud.cnpg.io,resources=objectstores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=barmancloud.cnpg.io,resources=objectstores/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=barmancloud.cnpg.io,resources=objectstores/finalizers,verbs=update


### PR DESCRIPTION
Barman plugin creates a role giving the rights for a managed CNPG cluster to interact with Barman-related resources (Objectstore, related secrets...).

https://github.com/cloudnative-pg/plugin-barman-cloud/blob/a225902a361f6bcb84679e150ce0d014bca0a0fb/internal/cnpgi/operator/reconciler.go#L121-L125

In order for the role to be cleaned up automatically when the related cluster is deleted, an **ownerReference** is set on the role pointing to that cluster.

https://github.com/cloudnative-pg/plugin-barman-cloud/blob/a225902a361f6bcb84679e150ce0d014bca0a0fb/internal/cnpgi/operator/reconciler.go#L144-L146

This causes an issue on all clusters with the [OwnerReferencesPermissionEnforcement](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement) admission controller configured, and so by consequence all Openshift / OKD clusters which by default have it enabled.

This is due to the fact that this AdmCon. requires the ServiceAccount creating an object with an ownerReference to also have the rights to update the `finalizers` subresource of the referenced owner. 

In our case, this means that the ServiceAccount used to create the role, must have the rights to update the finalizers field of a CNPG cluster object. 

Fixes #425 