### PR TITLE
fix: check for empty WAL archive during WAL archiving

### DIFF
--- a/internal/cnpgi/common/check.go
+++ b/internal/cnpgi/common/check.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"context"
+
+	"github.com/cloudnative-pg/barman-cloud/pkg/archiver"
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+)
+
+// CheckBackupDestination checks if the backup destination is suitable
+// to archive WALs
+func CheckBackupDestination(
+	ctx context.Context,
+	barmanConfiguration *cnpgv1.BarmanObjectStoreConfiguration,
+	barmanArchiver *archiver.WALArchiver,
+	serverName string,
+) error {
+	contextLogger := log.FromContext(ctx)
+	contextLogger.Info(
+		"Checking backup destination with barman-cloud-wal-archive",
+		"serverName", serverName)
+
+	// Get WAL archive options
+	checkWalOptions, err := barmanArchiver.BarmanCloudCheckWalArchiveOptions(
+		ctx, barmanConfiguration, serverName)
+	if err != nil {
+		log.Error(err, "while getting barman-cloud-wal-archive options")
+		return err
+	}
+
+	// Check if we're ok to archive in the desired destination
+	return barmanArchiver.CheckWalArchiveDestination(ctx, checkWalOptions)
+}

--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -266,17 +266,9 @@ func (impl *JobHookImpl) checkBackupDestination(
 		}
 	}
 
-	// Get WAL archive options
-	checkWalOptions, err := walArchiver.BarmanCloudCheckWalArchiveOptions(
-		ctx, barmanConfiguration, serverName)
-	if err != nil {
-		log.Error(err, "while getting barman-cloud-wal-archive options")
-		return err
-	}
-
 	// Check if we're ok to archive in the desired destination
 	if utils.IsEmptyWalArchiveCheckEnabled(&cluster.ObjectMeta) {
-		return walArchiver.CheckWalArchiveDestination(ctx, checkWalOptions)
+		return common.CheckBackupDestination(ctx, barmanConfiguration, walArchiver, serverName)
 	}
 
 	return nil


### PR DESCRIPTION
In the in-tree barman-cloud implementation, the check for an empty WAL archive is performed both immediately after the restore process and when the first WAL file is archived.

Previously, the plugin-based implementation only performed this check after restore, skipping it during archiving of the first WAL. This patch restores parity with the in-tree behavior by ensuring the check is also performed during WAL archiving.

Closes: #457