### PR TITLE
fix(images): use bookworm for sidecar image

### DIFF
--- a/containers/Dockerfile.sidecar
+++ b/containers/Dockerfile.sidecar
@@ -37,7 +37,7 @@ RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache
 # pip will build everything inside /usr/ since this is the case
 # we should build and then copy every file into a destination that will
 # then copy into the distroless container
-FROM python:3.13-slim AS pythonbuilder
+FROM python:3.13-slim-bookworm AS pythonbuilder
 COPY containers/sidecar-requirements.txt .
 RUN apt-get update && \
     apt-get install -y postgresql-common build-essential && \


### PR DESCRIPTION
We were using debian trixie as a building environment for barman-cloud, but we were still using bookworm as a base image. This caused inconsistencies in the sidecar image.

Now we always use bookworm.