### PR TITLE
fix(object-cache): improve reliability of object cache management

### DIFF
--- a/internal/cnpgi/instance/internal/client/client_test.go
+++ b/internal/cnpgi/instance/internal/client/client_test.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	v1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,16 +20,28 @@ var scheme = buildScheme()
 func buildScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = v1.AddToScheme(scheme)
+	_ = barmancloudv1.AddToScheme(scheme)
 
 	return scheme
+}
+
+func addToCache(c *ExtendedClient, obj client.Object, fetchUnixTime int64) {
+	ce := cachedEntry{
+		entry:         obj.DeepCopyObject().(client.Object),
+		fetchUnixTime: fetchUnixTime,
+		ttlSeconds:    DefaultTTLSeconds,
+	}
+	ce.entry.SetResourceVersion("from cache")
+	err := c.addTypeInformationToObject(ce.entry)
+	Expect(err).ToNot(HaveOccurred())
+	c.cachedObjects = append(c.cachedObjects, ce)
 }
 
 var _ = Describe("ExtendedClient Get", func() {
 	var (
 		extendedClient *ExtendedClient
 		secretInClient *corev1.Secret
-		objectStore    *v1.ObjectStore
+		objectStore    *barmancloudv1.ObjectStore
 	)
 
 	BeforeEach(func() {
@@ -39,12 +51,12 @@ var _ = Describe("ExtendedClient Get", func() {
 				Name:      "test-secret",
 			},
 		}
-		objectStore = &v1.ObjectStore{
+		objectStore = &barmancloudv1.ObjectStore{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "test-object-store",
 			},
-			Spec: v1.ObjectStoreSpec{},
+			Spec: barmancloudv1.ObjectStoreSpec{},
 		}
 
 		baseClient := fake.NewClientBuilder().
@@ -61,35 +73,34 @@ var _ = Describe("ExtendedClient Get", func() {
 			},
 		}
 
-		// manually add the secret to the cache, this is not present in the fake client so we are sure it is from the
-		// cache
-		extendedClient.cachedObjects = []cachedEntry{
-			{
-				entry:         secretNotInClient,
-				fetchUnixTime: time.Now().Unix(),
-			},
-		}
+		// manually add the secret to the cache, this is not present in the fake client,
+		// so we are sure it is from the cache
+		addToCache(extendedClient, secretNotInClient, time.Now().Unix())
 
 		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretNotInClient), secretInClient)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(secretNotInClient).To(Equal(extendedClient.cachedObjects[0].entry))
+		Expect(secretInClient).To(Equal(extendedClient.cachedObjects[0].entry))
+		Expect(secretInClient.GetResourceVersion()).To(Equal("from cache"))
 	})
 
 	It("fetches secret from base client if cache is expired", func(ctx SpecContext) {
-		extendedClient.cachedObjects = []cachedEntry{
-			{
-				entry:         secretInClient.DeepCopy(),
-				fetchUnixTime: time.Now().Add(-2 * time.Minute).Unix(),
-			},
-		}
+		addToCache(extendedClient, secretInClient, time.Now().Add(-2*time.Minute).Unix())
 
 		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretInClient), secretInClient)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(secretInClient.GetResourceVersion()).NotTo(Equal("from cache"))
+
+		// the cache is updated with the new value
+		Expect(extendedClient.cachedObjects).To(HaveLen(1))
+		Expect(extendedClient.cachedObjects[0].entry.GetResourceVersion()).NotTo(Equal("from cache"))
 	})
 
 	It("fetches secret from base client if not in cache", func(ctx SpecContext) {
 		err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretInClient), secretInClient)
 		Expect(err).NotTo(HaveOccurred())
+
+		// the cache is updated with the new value
+		Expect(extendedClient.cachedObjects).To(HaveLen(1))
 	})
 
 	It("does not cache non-secret objects", func(ctx SpecContext) {
@@ -106,4 +117,30 @@ var _ = Describe("ExtendedClient Get", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(extendedClient.cachedObjects).To(BeEmpty())
 	})
+
+	It("returns the correct object from cache when multiple objects with the same object key are cached",
+		func(ctx SpecContext) {
+			secretNotInClient := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "common-name",
+				},
+			}
+			objectStoreNotInClient := &barmancloudv1.ObjectStore{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "common-name",
+				},
+			}
+
+			// manually add the objects to the cache, these are not present in the fake client,
+			// so we are sure they are from the cache
+			addToCache(extendedClient, secretNotInClient, time.Now().Unix())
+			addToCache(extendedClient, objectStoreNotInClient, time.Now().Unix())
+
+			err := extendedClient.Get(ctx, client.ObjectKeyFromObject(secretNotInClient), secretInClient)
+			Expect(err).NotTo(HaveOccurred())
+			err = extendedClient.Get(ctx, client.ObjectKeyFromObject(objectStoreNotInClient), objectStore)
+			Expect(err).NotTo(HaveOccurred())
+		})
 })

--- a/internal/cnpgi/instance/internal/client/client_test.go
+++ b/internal/cnpgi/instance/internal/client/client_test.go
@@ -140,5 +140,8 @@ var _ = Describe("ExtendedClient Get", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = extendedClient.Get(ctx, client.ObjectKeyFromObject(objectStoreNotInClient), objectStore)
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(secretInClient.GetResourceVersion()).To(Equal("from cache"))
+			Expect(objectStore.GetResourceVersion()).To(Equal("from cache"))
 		})
 })

--- a/internal/cnpgi/instance/internal/client/client_test.go
+++ b/internal/cnpgi/instance/internal/client/client_test.go
@@ -32,8 +32,6 @@ func addToCache(c *ExtendedClient, obj client.Object, fetchUnixTime int64) {
 		ttlSeconds:    DefaultTTLSeconds,
 	}
 	ce.entry.SetResourceVersion("from cache")
-	err := c.addTypeInformationToObject(ce.entry)
-	Expect(err).ToNot(HaveOccurred())
 	c.cachedObjects = append(c.cachedObjects, ce)
 }
 


### PR DESCRIPTION
This patch addresses several critical bugs in the object cache logic.

First, it resolves a regression introduced in version 0.6.0, where WAL archival would fail if an ObjectStore and its corresponding credentials Secret had the same name. This issue caused the cache to return an object of the wrong type, leading to errors such as “cache had type *v1.ObjectStore, but *v1.Secret was asked for.” As a result, archival and backup operations were halted after the upgrade (see #502).

Second, the patch corrects the cache expiration logic. Previously, cached objects expired after only one second, which led to unnecessary reloads.

Third, there was a flaw in the function designed to remove objects from the cache. This bug prevented objects from being removed as intended.

Closes #502 