### PR TITLE
fix: typo in sidecar environment variable name

### DIFF
--- a/internal/cmd/instance/main.go
+++ b/internal/cmd/instance/main.go
@@ -39,7 +39,7 @@ func NewCmd() *cobra.Command {
 	_ = viper.BindEnv("pgdata", "PGDATA")
 	_ = viper.BindEnv("spool-directory", "SPOOL_DIRECTORY")
 	_ = viper.BindEnv("custom-cnpg-group", "CUSTOM_CNPG_GROUP")
-	_ = viper.BindEnv("custom-cnpg-version", "CUSTOM_CNPG_VERSIONXS")
+	_ = viper.BindEnv("custom-cnpg-version", "CUSTOM_CNPG_VERSION")
 
 	return cmd
 }


### PR DESCRIPTION
The environment variable CUSTOM_CNPG_VERSION (set in `internal/cnpgi/operator/lifecycle.go`) is read as CUSTOM_CNPG_VERSIONXS in `internal/cmd/instance/main.go`.

```
$git grep -n CUSTOM_CNPG_VERSION
internal/cmd/instance/main.go:42:       _ = viper.BindEnv("custom-cnpg-version", "CUSTOM_CNPG_VERSIONXS")
internal/cnpgi/operator/lifecycle.go:299:                       Name:  "CUSTOM_CNPG_VERSION",
```