### PR TITLE
fix: avoid panicking if serverRecoveryWindow has still not been set

### DIFF
--- a/internal/cnpgi/instance/recovery_window.go
+++ b/internal/cnpgi/instance/recovery_window.go
@@ -59,7 +59,12 @@ func setLastFailedBackupTime(
 		}
 		recoveryWindow := objectStore.Status.ServerRecoveryWindow[serverName]
 		recoveryWindow.LastFailedBackupTime = ptr.To(metav1.NewTime(lastFailedBackupTime))
+
+		if objectStore.Status.ServerRecoveryWindow == nil {
+			objectStore.Status.ServerRecoveryWindow = make(map[string]barmancloudv1.RecoveryWindow)
+		}
 		objectStore.Status.ServerRecoveryWindow[serverName] = recoveryWindow
+
 		return c.Status().Update(ctx, &objectStore)
 	})
 }


### PR DESCRIPTION
Closes: #523
