### PR TITLE
feat: introduce `logLevel` setting to control verbosity

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -13,6 +13,7 @@ DigitalOcean
 Docusaurus
 EDB
 EKS
+Enum
 EnvVar
 GCP
 GKE

--- a/api/v1/objectstore_types.go
+++ b/api/v1/objectstore_types.go
@@ -41,8 +41,15 @@ type InstanceSidecarConfiguration struct {
 	// AdditionalContainerArgs is an optional list of command-line arguments
 	// to be passed to the sidecar container when it starts.
 	// The provided arguments are appended to the container’s default arguments.
+	// +kubebuilder:validation:XValidation:rule="!self.exists(a, a.startsWith('--log-level'))",reason="FieldValueForbidden",message="do not set --log-level in additionalContainerArgs; use spec.instanceSidecarConfiguration.logLevel"
 	// +optional
 	AdditionalContainerArgs []string `json:"additionalContainerArgs,omitempty"`
+
+	// The instances' log level, one of the following values: error, warning, info (default), debug, trace
+	// +kubebuilder:default:=info
+	// +kubebuilder:validation:Enum:=error;warning;info;debug;trace
+	// +optional
+	LogLevel string `json:"logLevel,omitempty"`
 }
 
 // ObjectStoreSpec defines the desired state of ObjectStore.

--- a/api/v1/objectstore_types.go
+++ b/api/v1/objectstore_types.go
@@ -45,7 +45,7 @@ type InstanceSidecarConfiguration struct {
 	// +optional
 	AdditionalContainerArgs []string `json:"additionalContainerArgs,omitempty"`
 
-	// The instances' log level, one of the following values: error, warning, info (default), debug, trace
+	// The log level for PostgreSQL instances. Valid values are: `error`, `warning`, `info` (default), `debug`, `trace`
 	// +kubebuilder:default:=info
 	// +kubebuilder:validation:Enum:=error;warning;info;debug;trace
 	// +optional

--- a/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+++ b/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
@@ -564,8 +564,8 @@ spec:
                     type: array
                   logLevel:
                     default: info
-                    description: 'The instances'' log level, one of the following
-                      values: error, warning, info (default), debug, trace'
+                    description: 'The log level for PostgreSQL instances. Valid values
+                      are: `error`, `warning`, `info` (default), `debug`, `trace`'
                     enum:
                     - error
                     - warning

--- a/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+++ b/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
@@ -399,6 +399,11 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-validations:
+                    - message: do not set --log-level in additionalContainerArgs;
+                        use spec.instanceSidecarConfiguration.logLevel
+                      reason: FieldValueForbidden
+                      rule: '!self.exists(a, a.startsWith(''--log-level''))'
                   env:
                     description: The environment to be explicitly passed to the sidecar
                     items:
@@ -557,6 +562,17 @@ spec:
                       - name
                       type: object
                     type: array
+                  logLevel:
+                    default: info
+                    description: 'The instances'' log level, one of the following
+                      values: error, warning, info (default), debug, trace'
+                    enum:
+                    - error
+                    - warning
+                    - info
+                    - debug
+                    - trace
+                    type: string
                   resources:
                     description: Resources define cpu/memory requests and limits for
                       the sidecar that runs in the instance pods.

--- a/hack/examples/minio-store.yaml
+++ b/hack/examples/minio-store.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   retentionPolicy: "1m"
   instanceSidecarConfiguration:
+    logLevel: "debug"
     retentionPolicyIntervalSeconds: 1800
     resources:
       requests:
@@ -13,8 +14,6 @@ spec:
       limits:
         memory: "512Mi"
         cpu: "500m"
-    additionalContainerArgs:
-    - --log-level=debug
   configuration:
     endpointCA:
       name: minio-server-tls

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -563,8 +563,8 @@ spec:
                     type: array
                   logLevel:
                     default: info
-                    description: 'The instances'' log level, one of the following
-                      values: error, warning, info (default), debug, trace'
+                    description: 'The log level for PostgreSQL instances. Valid values
+                      are: `error`, `warning`, `info` (default), `debug`, `trace`'
                     enum:
                     - error
                     - warning

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -398,6 +398,11 @@ spec:
                     items:
                       type: string
                     type: array
+                    x-kubernetes-validations:
+                    - message: do not set --log-level in additionalContainerArgs;
+                        use spec.instanceSidecarConfiguration.logLevel
+                      reason: FieldValueForbidden
+                      rule: '!self.exists(a, a.startsWith(''--log-level''))'
                   env:
                     description: The environment to be explicitly passed to the sidecar
                     items:
@@ -556,6 +561,17 @@ spec:
                       - name
                       type: object
                     type: array
+                  logLevel:
+                    default: info
+                    description: 'The instances'' log level, one of the following
+                      values: error, warning, info (default), debug, trace'
+                    enum:
+                    - error
+                    - warning
+                    - info
+                    - debug
+                    - trace
+                    type: string
                   resources:
                     description: Resources define cpu/memory requests and limits for
                       the sidecar that runs in the instance pods.

--- a/web/docs/plugin-barman-cloud.v1.md
+++ b/web/docs/plugin-barman-cloud.v1.md
@@ -30,6 +30,7 @@ _Appears in:_
 | `retentionPolicyIntervalSeconds` _integer_ | The retentionCheckInterval defines the frequency at which the<br />system checks and enforces retention policies. |  | 1800 |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | Resources define cpu/memory requests and limits for the sidecar that runs in the instance pods. |  |  |  |
 | `additionalContainerArgs` _string array_ | AdditionalContainerArgs is an optional list of command-line arguments<br />to be passed to the sidecar container when it starts.<br />The provided arguments are appended to the container’s default arguments. |  |  |  |
+| `logLevel` _string_ | The instances' log level, one of the following values: error, warning, info (default), debug, trace |  | info | Enum: [error warning info debug trace] <br /> |
 
 
 #### ObjectStore

--- a/web/docs/plugin-barman-cloud.v1.md
+++ b/web/docs/plugin-barman-cloud.v1.md
@@ -30,7 +30,7 @@ _Appears in:_
 | `retentionPolicyIntervalSeconds` _integer_ | The retentionCheckInterval defines the frequency at which the<br />system checks and enforces retention policies. |  | 1800 |  |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#resourcerequirements-v1-core)_ | Resources define cpu/memory requests and limits for the sidecar that runs in the instance pods. |  |  |  |
 | `additionalContainerArgs` _string array_ | AdditionalContainerArgs is an optional list of command-line arguments<br />to be passed to the sidecar container when it starts.<br />The provided arguments are appended to the container’s default arguments. |  |  |  |
-| `logLevel` _string_ | The instances' log level, one of the following values: error, warning, info (default), debug, trace |  | info | Enum: [error warning info debug trace] <br /> |
+| `logLevel` _string_ | The log level for PostgreSQL instances. Valid values are: `error`, `warning`, `info` (default), `debug`, `trace` |  | info | Enum: [error warning info debug trace] <br /> |
 
 
 #### ObjectStore


### PR DESCRIPTION
This commit adds a new `logLevel` field to the plugin configuration,
allowing users to select the desired log verbosity for the instances
(e.g. error, warning, info, debug, trace).

Closes #514 