### PR TITLE
feat: return proper gRPC error codes for expected conditions

### DIFF
--- a/internal/cnpgi/common/errors.go
+++ b/internal/cnpgi/common/errors.go
@@ -1,8 +1,6 @@
 package common
 
 import (
-	"fmt"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -15,7 +13,8 @@ var ErrEndOfWALStreamReached = status.Errorf(codes.OutOfRange, "end of WAL reach
 // the object storage.
 // This will be fixed by the reconciliation loop in the
 // operator plugin.
-var ErrMissingPermissions = fmt.Errorf("no permission to download the backup credentials, retrying")
+var ErrMissingPermissions = status.Errorf(codes.FailedPrecondition,
+	"no permission to download the backup credentials, retrying")
 
 // newWALNotFoundError returns a error that states that a
 // certain WAL file has not been found. This error is

--- a/internal/cnpgi/common/errors.go
+++ b/internal/cnpgi/common/errors.go
@@ -1,16 +1,14 @@
 package common
 
-// walNotFoundError is raised when a WAL file has not been found in the object store
-type walNotFoundError struct{}
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
-func newWALNotFoundError() *walNotFoundError { return &walNotFoundError{} }
-
-// ShouldPrintStackTrace tells whether the sidecar log stream should contain the stack trace
-func (e walNotFoundError) ShouldPrintStackTrace() bool {
-	return false
-}
-
-// Error implements the error interface
-func (e walNotFoundError) Error() string {
-	return "WAL file not found"
+// newWALNotFoundError returns a error that states that a
+// certain WAL file has not been found. This error is
+// compatible with GRPC status codes, resulting in a 404
+// being used as a response code.
+func newWALNotFoundError(walName string) error {
+	return status.Errorf(codes.NotFound, "wal %q not found", walName)
 }

--- a/internal/cnpgi/common/errors.go
+++ b/internal/cnpgi/common/errors.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ErrEndOfWALStreamReached is returned when end of WAL is detected in the cloud archive.
-var ErrEndOfWALStreamReached = status.Errorf(codes.NotFound, "end of WAL reached")
+var ErrEndOfWALStreamReached = status.Errorf(codes.OutOfRange, "end of WAL reached")
 
 // ErrMissingPermissions is raised when the sidecar has no
 // permission to download the credentials needed to reach

--- a/internal/cnpgi/common/errors.go
+++ b/internal/cnpgi/common/errors.go
@@ -1,9 +1,21 @@
 package common
 
 import (
+	"fmt"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ErrEndOfWALStreamReached is returned when end of WAL is detected in the cloud archive.
+var ErrEndOfWALStreamReached = status.Errorf(codes.NotFound, "end of WAL reached")
+
+// ErrMissingPermissions is raised when the sidecar has no
+// permission to download the credentials needed to reach
+// the object storage.
+// This will be fixed by the reconciliation loop in the
+// operator plugin.
+var ErrMissingPermissions = fmt.Errorf("no permission to download the backup credentials, retrying")
 
 // newWALNotFoundError returns a error that states that a
 // certain WAL file has not been found. This error is

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -88,10 +88,13 @@ func (w WALServiceImplementation) Archive(
 	ctx context.Context,
 	request *wal.WALArchiveRequest,
 ) (*wal.WALArchiveResult, error) {
-	contextLogger := log.FromContext(ctx)
-	contextLogger.Debug("starting wal archive")
-
 	baseWalName := path.Base(request.GetSourceFileName())
+
+	contextLogger := log.FromContext(ctx)
+	contextLogger.Debug("wal archive start", "walName", baseWalName)
+	defer func() {
+		contextLogger.Debug("wal archive end", "walName", baseWalName)
+	}()
 
 	// Step 1: parse the configuration and get the environment variables needed
 	// for barman-cloud-wal-archive
@@ -115,6 +118,7 @@ func (w WALServiceImplementation) Archive(
 	)
 	if err != nil {
 		if apierrors.IsForbidden(err) {
+			contextLogger.Info(ErrMissingPermissions.Error())
 			return nil, ErrMissingPermissions
 		}
 		return nil, err

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/fileutils"
 	walUtils "github.com/cloudnative-pg/machinery/pkg/fileutils/wals"
 	"github.com/cloudnative-pg/machinery/pkg/log"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,13 +26,6 @@ import (
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/operator/config"
 )
-
-// ErrMissingPermissions is raised when the sidecar has no
-// permission to download the credentials needed to reach
-// the object storage.
-// This will be fixed by the reconciliation loop in the
-// operator plugin.
-var ErrMissingPermissions = fmt.Errorf("no permission to download the backup credentials, retrying")
 
 // SpoolManagementError is raised when a spool management
 // error has been detected
@@ -458,9 +449,6 @@ func gatherWALFilesToRestore(walName string, parallel int) (walList []string, er
 
 	return walList, err
 }
-
-// ErrEndOfWALStreamReached is returned when end of WAL is detected in the cloud archive.
-var ErrEndOfWALStreamReached = status.Errorf(codes.NotFound, "end of WAL reached")
 
 // checkEndOfWALStreamFlag returns ErrEndOfWALStreamReached if the flag is set in the restorer.
 func checkEndOfWALStreamFlag(walRestorer *barmanRestorer.WALRestorer) error {


### PR DESCRIPTION
The plugin now returns a 404 status code when a requested WAL file does not exist in the object store.

This prevents misleading log entries such as "Error while handling gRPC request" for expected missing-file scenarios.

The `ErrEndOfWALStreamReached` now returns `OutOfRange` error.

The `ErrMissingPermissions` now returns `FailedPrecondition` error.