### PR TITLE
Remove runAs directive

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -58,8 +58,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 10001
-          runAsUser: 10001
           seccompProfile:
             type: RuntimeDefault
       volumes:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1016,8 +1016,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 10001
-          runAsUser: 10001
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:


### PR DESCRIPTION
OpenShift doesn't allow fixed UIDs on default. [See here](https://www.redhat.com/en/blog/a-guide-to-openshift-and-uids) and [here](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/images/creating-images#use-uid_create-images)

For this case this PR removes the fixed UIDs for `runAsUser` and `runAsGroup` to allow users installing Barman on OpenShift without further modifications.