### PR TITLE
fix: don't log full environment variables at default log level

### DIFF
--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -157,7 +157,7 @@ func (impl JobHookImpl) Restore(
 
 	config := getRestoreWalConfig()
 
-	contextLogger.Info("sending restore response", "config", config, "env", env)
+	contextLogger.Info("sending restore response", "config", config)
 	return &restore.RestoreResponse{
 		RestoreConfig: config,
 		Envs:          nil,


### PR DESCRIPTION
Logging the full environment of the plugin container can potentially result in an unnecessarily long log line, but perhaps more importantly the credentials are visible as well.