### PR TITLE
docs: add Helm chart installation

### DIFF
--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -54,7 +54,45 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
+import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
+
+<Tabs groupId="install-method">
+  <TabItem value="helm" label="Helm Chart" default>
+
+The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
+
+<HelmInstallationSnippet />
+
+Example output:
+
+```output
+Release "plugin-barman-cloud" does not exist. Installing it now.
+NAME: plugin-barman-cloud
+LAST DEPLOYED: Wed Jul  1 09:05:16 2026
+NAMESPACE: cnpg-system
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete
+TEST SUITE: None
+```
+
+Finally, check that the deployment is up and running:
+
+```sh
+kubectl -n cnpg-system rollout status deploy/plugin-barman-cloud
+```
+
+Example output:
+
+```output
+deployment "plugin-barman-cloud" successfully rolled out
+```
+
+  </TabItem>
+  <TabItem value="kubectl" label="Manifest (kubectl)">
 
 Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
@@ -85,8 +123,7 @@ issuer.cert-manager.io/selfsigned-issuer created
 Finally, check that the deployment is up and running:
 
 ```sh
-kubectl rollout status deployment \
-  -n cnpg-system barman-cloud
+kubectl -n cnpg-system rollout status deploy/barman-cloud
 ```
 
 Example output:
@@ -94,6 +131,11 @@ Example output:
 ```output
 deployment "barman-cloud" successfully rolled out
 ```
+
+  </TabItem>
+</Tabs>
+
+---
 
 This confirms that the plugin is deployed and ready to use.
 

--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -59,10 +59,12 @@ import TabItem from '@theme/TabItem';
 import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
 import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
 
-<Tabs groupId="install-method">
+<Tabs groupId="install-method" queryString>
   <TabItem value="helm" label="Helm Chart" default>
 
-The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
+The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud).
+This installs the latest published chart release; to test an unreleased
+development snapshot instead, switch to the [**Manifest (kubectl)**](./?install-method=kubectl#installing-the-barman-cloud-plugin) tab.
 
 <HelmInstallationSnippet />
 

--- a/web/docs/troubleshooting.md
+++ b/web/docs/troubleshooting.md
@@ -485,14 +485,10 @@ If problems persist:
 
 ### Plugin Limitations
 
-1. **Installation method**: Currently only supports manifest and Kustomize
-   installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) -
-   Helm chart requested)
-
-2. **Sidecar resource sharing**: The plugin sidecar container shares pod
+1. **Sidecar resource sharing**: The plugin sidecar container shares pod
    resources with PostgreSQL
 
-3. **Plugin restart behavior**: Restarting the sidecar container requires
+2. **Plugin restart behavior**: Restarting the sidecar container requires
    restarting the entire PostgreSQL pod
 
 ## Recap of General Debugging Steps
@@ -588,4 +584,3 @@ kubectl get secret -n <namespace> <secret-name> -o jsonpath='{.data}' | jq 'keys
 * **"NoSuchBucket"** — Verify the bucket exists and the endpoint URL is correct.
 * **"Connection timeout"** — Check network connectivity and firewall rules.
 * **"SSL certificate problem"** — For self-signed certificates, verify the CA bundle configuration.
-

--- a/web/src/components/HelmInstallation/index.tsx
+++ b/web/src/components/HelmInstallation/index.tsx
@@ -1,22 +1,36 @@
-import { ReactElement } from "react";
-import CodeBlock from "@theme/CodeBlock";
+import {ReactElement} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import {useActiveVersion, useLatestVersion} from '@docusaurus/plugin-content-docs/client';
 
-type HelmInstallationProps = {
-  chartVersion?: string;
-};
-
-// HelmInstallationSnippet is the Helm incantation to install a specific
-// or latest available version of the Barman Cloud Plugin.
-export function HelmInstallationSnippet({
-  chartVersion,
-}: HelmInstallationProps): ReactElement<null> {
-  const versionArg = chartVersion ? `\n  --version ${chartVersion} \\` : "";
-  return (
-    <CodeBlock language="sh">
-      {`helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update
+// HelmInstallationSnippet is the Helm command to install the plugin.
+//
+// - Latest release: no override. The chart already defaults to
+//   itself.
+// - Older release: pin image.tag and sidecarImage.tag to that
+//   version. We check this again on every build using
+//   useLatestVersion, so an old page updates itself once a newer
+//   version ships.
+// - Dev docs: also no override, but this does NOT install a dev
+//   build. Setting the tag alone would not be enough, since the
+//   chart's own templates (CRDs, RBAC...) can be older than what
+//   main needs. Use the kubectl method to test a dev build.
+export function HelmInstallationSnippet(): ReactElement<null> {
+    const activeVersion = useActiveVersion('default');
+    const latestVersion = useLatestVersion('default');
+    const isOlderRelease = activeVersion
+        && activeVersion.name !== 'current'
+        && activeVersion.name !== latestVersion.name;
+    const setArgs = isOlderRelease
+        ? ` \\
+  --set image.tag=v${activeVersion.name} \\
+  --set sidecarImage.tag=v${activeVersion.name}`
+        : '';
+    return (
+        <CodeBlock language="sh">
+            {`helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update
 helm upgrade --install plugin-barman-cloud \\
-  --namespace cnpg-system \\${versionArg}
+  --namespace cnpg-system${setArgs} \\
   cnpg/plugin-barman-cloud`}
-    </CodeBlock>
-  );
+        </CodeBlock>
+    );
 }

--- a/web/src/components/HelmInstallation/index.tsx
+++ b/web/src/components/HelmInstallation/index.tsx
@@ -1,0 +1,22 @@
+import { ReactElement } from "react";
+import CodeBlock from "@theme/CodeBlock";
+
+type HelmInstallationProps = {
+  chartVersion?: string;
+};
+
+// HelmInstallationSnippet is the Helm incantation to install a specific
+// or latest available version of the Barman Cloud Plugin.
+export function HelmInstallationSnippet({
+  chartVersion,
+}: HelmInstallationProps): ReactElement<null> {
+  const versionArg = chartVersion ? `\n  --version ${chartVersion} \\` : "";
+  return (
+    <CodeBlock language="sh">
+      {`helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update
+helm upgrade --install plugin-barman-cloud \\
+  --namespace cnpg-system \\${versionArg}
+  cnpg/plugin-barman-cloud`}
+    </CodeBlock>
+  );
+}

--- a/web/src/components/Installation/index.tsx
+++ b/web/src/components/Installation/index.tsx
@@ -1,5 +1,7 @@
 import {ReactElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
+import Link from '@docusaurus/Link';
+import {useLocation} from '@docusaurus/router';
 import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
 
 // DEV_MANIFEST_URL is the URL of the manifest.yaml on the main branch of the plugin repo.
@@ -31,14 +33,17 @@ export function ManifestVersion(): ReactElement<null> {
         : <>the latest development snapshot from the <code>main</code> branch</>;
 }
 
-// DevSnapshotSection offers the main-branch manifest as an alternative;
-// on the Dev docs the main install already is that manifest, so hide it.
+// DevSnapshotSection shows how to test the main-branch manifest. On
+// the Dev docs, the kubectl install above already does that, so we
+// hide this section there. (The Helm tab there installs the latest
+// release, not a dev build.)
 export function DevSnapshotSection(): ReactElement {
     const activeVersion = useActiveVersion('default');
+    const {pathname} = useLocation();
     if (!activeVersion || activeVersion.name === 'current') {
         return (
-            <p>The <a href="#installing-the-barman-cloud-plugin">install
-                command above</a> already applies the latest development
+            <p>The <Link to={`${pathname}?install-method=kubectl#installing-the-barman-cloud-plugin`}>kubectl
+                install command above</Link> already applies the latest development
                 snapshot from the <code>main</code> branch.</p>
         );
     }

--- a/web/versioned_docs/version-0.13.0/installation.mdx
+++ b/web/versioned_docs/version-0.13.0/installation.mdx
@@ -64,7 +64,7 @@ import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
 
 The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
 
-<HelmInstallationSnippet chartVersion="0.7.0" />
+<HelmInstallationSnippet />
 
 Example output:
 

--- a/web/versioned_docs/version-0.13.0/installation.mdx
+++ b/web/versioned_docs/version-0.13.0/installation.mdx
@@ -54,7 +54,45 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
+import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
+
+<Tabs groupId="install-method">
+  <TabItem value="helm" label="Helm Chart" default>
+
+The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
+
+<HelmInstallationSnippet chartVersion="0.7.0" />
+
+Example output:
+
+```output
+Release "plugin-barman-cloud" does not exist. Installing it now.
+NAME: plugin-barman-cloud
+LAST DEPLOYED: Wed Jul  1 09:05:16 2026
+NAMESPACE: cnpg-system
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete
+TEST SUITE: None
+```
+
+Finally, check that the deployment is up and running:
+
+```sh
+kubectl -n cnpg-system rollout status deploy/plugin-barman-cloud
+```
+
+Example output:
+
+```output
+deployment "plugin-barman-cloud" successfully rolled out
+```
+
+  </TabItem>
+  <TabItem value="kubectl" label="Manifest (kubectl)">
 
 Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
@@ -85,8 +123,7 @@ issuer.cert-manager.io/selfsigned-issuer created
 Finally, check that the deployment is up and running:
 
 ```sh
-kubectl rollout status deployment \
-  -n cnpg-system barman-cloud
+kubectl -n cnpg-system rollout status deploy/barman-cloud
 ```
 
 Example output:
@@ -94,6 +131,11 @@ Example output:
 ```output
 deployment "barman-cloud" successfully rolled out
 ```
+
+  </TabItem>
+</Tabs>
+
+---
 
 This confirms that the plugin is deployed and ready to use.
 

--- a/web/versioned_docs/version-0.13.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.13.0/troubleshooting.md
@@ -485,14 +485,10 @@ If problems persist:
 
 ### Plugin Limitations
 
-1. **Installation method**: Currently only supports manifest and Kustomize
-   installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) -
-   Helm chart requested)
-
-2. **Sidecar resource sharing**: The plugin sidecar container shares pod
+1. **Sidecar resource sharing**: The plugin sidecar container shares pod
    resources with PostgreSQL
 
-3. **Plugin restart behavior**: Restarting the sidecar container requires
+2. **Plugin restart behavior**: Restarting the sidecar container requires
    restarting the entire PostgreSQL pod
 
 ## Recap of General Debugging Steps
@@ -588,4 +584,3 @@ kubectl get secret -n <namespace> <secret-name> -o jsonpath='{.data}' | jq 'keys
 * **"NoSuchBucket"** — Verify the bucket exists and the endpoint URL is correct.
 * **"Connection timeout"** — Check network connectivity and firewall rules.
 * **"SSL certificate problem"** — For self-signed certificates, verify the CA bundle configuration.
-

--- a/web/versioned_docs/version-0.14.0/installation.mdx
+++ b/web/versioned_docs/version-0.14.0/installation.mdx
@@ -64,7 +64,7 @@ import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
 
 The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
 
-<HelmInstallationSnippet chartVersion="0.7.1" />
+<HelmInstallationSnippet />
 
 Example output:
 

--- a/web/versioned_docs/version-0.14.0/installation.mdx
+++ b/web/versioned_docs/version-0.14.0/installation.mdx
@@ -54,7 +54,45 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
+import { HelmInstallationSnippet } from '@site/src/components/HelmInstallation';
+
+<Tabs groupId="install-method">
+  <TabItem value="helm" label="Helm Chart" default>
+
+The plugin can be installed using the provided [Helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud):
+
+<HelmInstallationSnippet chartVersion="0.7.1" />
+
+Example output:
+
+```output
+Release "plugin-barman-cloud" does not exist. Installing it now.
+NAME: plugin-barman-cloud
+LAST DEPLOYED: Wed Jul  1 09:05:16 2026
+NAMESPACE: cnpg-system
+STATUS: deployed
+REVISION: 1
+DESCRIPTION: Install complete
+TEST SUITE: None
+```
+
+Finally, check that the deployment is up and running:
+
+```sh
+kubectl -n cnpg-system rollout status deploy/plugin-barman-cloud
+```
+
+Example output:
+
+```output
+deployment "plugin-barman-cloud" successfully rolled out
+```
+
+  </TabItem>
+  <TabItem value="kubectl" label="Manifest (kubectl)">
 
 Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
@@ -85,8 +123,7 @@ issuer.cert-manager.io/selfsigned-issuer created
 Finally, check that the deployment is up and running:
 
 ```sh
-kubectl rollout status deployment \
-  -n cnpg-system barman-cloud
+kubectl -n cnpg-system rollout status deploy/barman-cloud
 ```
 
 Example output:
@@ -94,6 +131,9 @@ Example output:
 ```output
 deployment "barman-cloud" successfully rolled out
 ```
+
+  </TabItem>
+</Tabs>
 
 This confirms that the plugin is deployed and ready to use.
 

--- a/web/versioned_docs/version-0.14.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.14.0/troubleshooting.md
@@ -485,14 +485,10 @@ If problems persist:
 
 ### Plugin Limitations
 
-1. **Installation method**: Currently only supports manifest and Kustomize
-   installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) -
-   Helm chart requested)
-
-2. **Sidecar resource sharing**: The plugin sidecar container shares pod
+1. **Sidecar resource sharing**: The plugin sidecar container shares pod
    resources with PostgreSQL
 
-3. **Plugin restart behavior**: Restarting the sidecar container requires
+2. **Plugin restart behavior**: Restarting the sidecar container requires
    restarting the entire PostgreSQL pod
 
 ## Recap of General Debugging Steps
@@ -588,4 +584,3 @@ kubectl get secret -n <namespace> <secret-name> -o jsonpath='{.data}' | jq 'keys
 * **"NoSuchBucket"** — Verify the bucket exists and the endpoint URL is correct.
 * **"Connection timeout"** — Check network connectivity and firewall rules.
 * **"SSL certificate problem"** — For self-signed certificates, verify the CA bundle configuration.
-


### PR DESCRIPTION
Add Helm chart install steps next to kubectl, for the current docs and the 0.13.0 and 0.14.0 versioned snapshots.

Pin the chart's image tag to the plugin version on older releases. The chart ships after the plugin, so its own version numbers don't map to ours, and we skip the pin on the latest release since the chart already defaults to itself there.

On the current docs, make clear the Helm tab installs the latest release, not a main-branch build. Only kubectl can test a main-branch build.

Closes #351