### PR TITLE
fix: set LeaderElectionReleaseOnCancel to true to enable RollingUpdates

### DIFF
--- a/internal/cnpgi/operator/manager.go
+++ b/internal/cnpgi/operator/manager.go
@@ -119,7 +119,7 @@ func Start(ctx context.Context) error {
 		// the manager stops, so would be fine to enable this option. However,
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
+		LeaderElectionReleaseOnCancel: true,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
Enable the LeaderElectionReleaseOnCancel option in the controller manager to fix a deadlock issue during RollingUpdate deployments with leader election enabled.

Without this setting, the old pod holds the leader lease during shutdown, preventing the new pod from becoming ready. This creates a deadlock where Kubernetes won't terminate the old pod because the new pod isn't ready, and the new pod can't become ready because it can't acquire the lease.

With LeaderElectionReleaseOnCancel enabled, the old pod voluntarily releases the lease when it receives a shutdown signal, allowing the new pod to acquire leadership immediately and become ready, enabling smooth rolling updates.

Closes #419 
 
