### PR TITLE
feat: remove wal from cache after archiving

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.4
 require (
 	github.com/cert-manager/cert-manager v1.19.1
 	github.com/cloudnative-pg/api v1.27.0
-	github.com/cloudnative-pg/barman-cloud v0.3.3
+	github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7
 	github.com/cloudnative-pg/cloudnative-pg v1.27.1
 	github.com/cloudnative-pg/cnpg-i v0.3.0
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.1

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.4
 require (
 	github.com/cert-manager/cert-manager v1.19.1
 	github.com/cloudnative-pg/api v1.27.0
-	github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7
+	github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251203100017-1d476f125c5b
 	github.com/cloudnative-pg/cloudnative-pg v1.27.1
 	github.com/cloudnative-pg/cnpg-i v0.3.0
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.27.0 h1:uSUkF9X/0UZu1Xn5qI33qHVmzZrDKuuyoiRlsOmSTv4=
 github.com/cloudnative-pg/api v1.27.0/go.mod h1:IWyAmuirffHiw6iIGD1p18BmZNb13TK9Os/wkp8ltDg=
-github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7 h1:yfR+SbGLzaEfQOWTCfBtvG1zgVAsxvRe9CwepWzZc6E=
-github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7/go.mod h1:svkzKIpTe5qe6nQRd6MwmInRlL50RTYVpkgu959usus=
+github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251203100017-1d476f125c5b h1:7qpnZpOkmjhs0Prasu8laSaiEQ7eC2qW1xA39mQ/aEc=
+github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251203100017-1d476f125c5b/go.mod h1:F6JqmFpa3V0/8paxu372tvxH7F6NrfUbtul3zrsoy+k=
 github.com/cloudnative-pg/cloudnative-pg v1.27.1 h1:w+bbtXyEPoaa7sZGXxbb8qJ+/bUGWQ3M48kbNUEpKlk=
 github.com/cloudnative-pg/cloudnative-pg v1.27.1/go.mod h1:XbwCAlCm5fr+/A+v+qvMp8DHzVtJr2m0Y/TpKALw+Bk=
 github.com/cloudnative-pg/cnpg-i v0.3.0 h1:5ayNOG5x68lU70IVbHDZQrv5p+bErCJ0mqRmOpW2jjE=

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.27.0 h1:uSUkF9X/0UZu1Xn5qI33qHVmzZrDKuuyoiRlsOmSTv4=
 github.com/cloudnative-pg/api v1.27.0/go.mod h1:IWyAmuirffHiw6iIGD1p18BmZNb13TK9Os/wkp8ltDg=
-github.com/cloudnative-pg/barman-cloud v0.3.3 h1:EEcjeV+IUivDpmyF/H/XGY1pGaKJ5LS5MYeB6wgGcak=
-github.com/cloudnative-pg/barman-cloud v0.3.3/go.mod h1:5CM4MncAxAjnqxjDt0I5E/oVd7gsMLL0/o/wQ+vUSgs=
+github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7 h1:yfR+SbGLzaEfQOWTCfBtvG1zgVAsxvRe9CwepWzZc6E=
+github.com/cloudnative-pg/barman-cloud v0.3.4-0.20251201135428-8937882d37d7/go.mod h1:svkzKIpTe5qe6nQRd6MwmInRlL50RTYVpkgu959usus=
 github.com/cloudnative-pg/cloudnative-pg v1.27.1 h1:w+bbtXyEPoaa7sZGXxbb8qJ+/bUGWQ3M48kbNUEpKlk=
 github.com/cloudnative-pg/cloudnative-pg v1.27.1/go.mod h1:XbwCAlCm5fr+/A+v+qvMp8DHzVtJr2m0Y/TpKALw+Bk=
 github.com/cloudnative-pg/cnpg-i v0.3.0 h1:5ayNOG5x68lU70IVbHDZQrv5p+bErCJ0mqRmOpW2jjE=


### PR DESCRIPTION
## Summary

This PR fixes the memory leak in the plugin-barman-cloud container where memory usage continuously increases on primary instances during WAL archiving.

## Motivation

The plugin-barman-cloud container on primary instances was experiencing ever-increasing memory usage due to archived WAL files accumulating in the OS page cache. In Kubernetes environments running on large machines, memory pressure is typically insufficient to naturally evict these cached files, causing them to waste memory that could be used for active workloads.

## Changes

After successfully archiving a WAL file, the plugin now explicitly drops it from the OS page cache using `fadvise(FADV_DONTNEED)`. This prevents archived WALs from accumulating in memory and causing the observed memory leak.

## Dependencies

This PR depends on cloudnative-pg/barman-cloud#169

Closes #385