### PR TITLE
fix(docs): update documentation to use correct reference in plugin configuration snippet

### DIFF
--- a/web/docs/troubleshooting.md
+++ b/web/docs/troubleshooting.md
@@ -206,7 +206,7 @@ When a backup fails, follow these steps in order:
      plugins:
        - name: barman-cloud.cloudnative-pg.io
          parameters:
-           barmanObjectStore: <your-objectstore-name>
+           barmanObjectName: <your-objectstore-name>
    ```
    
    c. **Check plugin deployment is running**:

--- a/web/versioned_docs/version-0.7.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.7.0/troubleshooting.md
@@ -206,7 +206,7 @@ When a backup fails, follow these steps in order:
      plugins:
        - name: barman-cloud.cloudnative-pg.io
          parameters:
-           barmanObjectStore: <your-objectstore-name>
+           barmanObjectName: <your-objectstore-name>
    ```
    
    c. **Check plugin deployment is running**:

--- a/web/versioned_docs/version-0.8.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.8.0/troubleshooting.md
@@ -206,7 +206,7 @@ When a backup fails, follow these steps in order:
      plugins:
        - name: barman-cloud.cloudnative-pg.io
          parameters:
-           barmanObjectStore: <your-objectstore-name>
+           barmanObjectName: <your-objectstore-name>
    ```
    
    c. **Check plugin deployment is running**:

--- a/web/versioned_docs/version-0.9.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.9.0/troubleshooting.md
@@ -206,7 +206,7 @@ When a backup fails, follow these steps in order:
      plugins:
        - name: barman-cloud.cloudnative-pg.io
          parameters:
-           barmanObjectStore: <your-objectstore-name>
+           barmanObjectName: <your-objectstore-name>
    ```
    
    c. **Check plugin deployment is running**:


### PR DESCRIPTION
This updates the documentation to use the correct reference to the ObjectStore, as defined in https://github.com/cloudnative-pg/plugin-barman-cloud/blob/316828cc73b76fe33c2aba66cdcd6e7280def069/internal/cnpgi/operator/config/config.go#L71