### PR TITLE
feat(auth): add support for DefaultAzureCredential

### DIFF
--- a/containers/Dockerfile.plugin
+++ b/containers/Dockerfile.plugin
@@ -15,6 +15,7 @@ RUN go mod download
 COPY ../cmd/manager/main.go cmd/manager/main.go
 COPY ../api/ api/
 COPY ../internal/ internal/
+COPY ../pkg/ pkg/
 
 ENV GOCACHE=/root/.cache/go-build
 ENV GOMODCACHE=/go/pkg/mod

--- a/containers/Dockerfile.sidecar
+++ b/containers/Dockerfile.sidecar
@@ -24,6 +24,7 @@ ENV GOMODCACHE=/go/pkg/mod
 COPY ../cmd/manager/main.go cmd/manager/main.go
 COPY ../api/ api/
 COPY ../internal/ internal/
+COPY ../pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/internal/cnpgi/common/common.go
+++ b/internal/cnpgi/common/common.go
@@ -105,8 +105,8 @@ func BuildCertificateFilePath(objectStoreName string) string {
 // ContextWithProviderOptions enriches the context with cloud service provider specific options
 // based on the ObjectStore resource
 func ContextWithProviderOptions(ctx context.Context, objectStore apiv1.ObjectStore) context.Context {
-	if objectStore.GetAnnotations()[pluginmetadata.UseDefaultAzureCredentialsAnnotationName] ==
-		pluginmetadata.UseDefaultAzureCredentialsTrueValue {
+	if objectStore.GetAnnotations()[pluginmetadata.UseDefaultAzureCredentialAnnotationName] ==
+		pluginmetadata.UseDefaultAzureCredentialTrueValue {
 		return command.ContextWithDefaultAzureCredentials(ctx, true)
 	}
 

--- a/internal/cnpgi/common/common.go
+++ b/internal/cnpgi/common/common.go
@@ -28,7 +28,7 @@ import (
 	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
 	"github.com/cloudnative-pg/barman-cloud/pkg/command"
 
-	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	apiv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
 	pluginmetadata "github.com/cloudnative-pg/plugin-barman-cloud/pkg/metadata"
 )
@@ -104,7 +104,7 @@ func BuildCertificateFilePath(objectStoreName string) string {
 
 // ContextWithProviderOptions enriches the context with cloud service provider specific options
 // based on the ObjectStore resource
-func ContextWithProviderOptions(ctx context.Context, objectStore barmancloudv1.ObjectStore) context.Context {
+func ContextWithProviderOptions(ctx context.Context, objectStore apiv1.ObjectStore) context.Context {
 	if objectStore.GetAnnotations()[pluginmetadata.UseDefaultAzureCredentialsAnnotationName] ==
 		pluginmetadata.UseDefaultAzureCredentialsTrueValue {
 		return command.ContextWithDefaultAzureCredentials(ctx, true)

--- a/internal/cnpgi/common/common.go
+++ b/internal/cnpgi/common/common.go
@@ -20,13 +20,17 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"strings"
 
 	barmanapi "github.com/cloudnative-pg/barman-cloud/pkg/api"
+	"github.com/cloudnative-pg/barman-cloud/pkg/command"
 
+	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
 	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/metadata"
+	pluginmetadata "github.com/cloudnative-pg/plugin-barman-cloud/pkg/metadata"
 )
 
 // TODO: refactor.
@@ -96,4 +100,15 @@ func MergeEnv(env []string, incomingEnv []string) []string {
 // BuildCertificateFilePath builds the path to the barman objectStore certificate
 func BuildCertificateFilePath(objectStoreName string) string {
 	return path.Join(metadata.BarmanCertificatesPath, objectStoreName, metadata.BarmanCertificatesFileName)
+}
+
+// ContextWithProviderOptions enriches the context with cloud service provider specific options
+// based on the ObjectStore resource
+func ContextWithProviderOptions(ctx context.Context, objectStore barmancloudv1.ObjectStore) context.Context {
+	if objectStore.GetAnnotations()[pluginmetadata.UseDefaultAzureCredentialsAnnotationName] ==
+		pluginmetadata.UseDefaultAzureCredentialsTrueValue {
+		return command.ContextWithDefaultAzureCredentials(ctx, true)
+	}
+
+	return ctx
 }

--- a/internal/cnpgi/common/wal.go
+++ b/internal/cnpgi/common/wal.go
@@ -127,6 +127,8 @@ func (w WALServiceImplementation) Archive(
 		return nil, err
 	}
 
+	ctx = ContextWithProviderOptions(ctx, objectStore)
+
 	envArchive, err := barmanCredentials.EnvSetCloudCredentialsAndCertificates(
 		ctx,
 		w.Client,

--- a/internal/cnpgi/instance/backup.go
+++ b/internal/cnpgi/instance/backup.go
@@ -87,6 +87,8 @@ func (b BackupServiceImplementation) Backup(
 		return nil, err
 	}
 
+	ctx = common.ContextWithProviderOptions(ctx, objectStore)
+
 	if err := fileutils.EnsureDirectoryExists(postgres.BackupTemporaryDirectory); err != nil {
 		contextLogger.Error(err, "Cannot create backup temporary directory", "err", err)
 		return nil, err

--- a/internal/cnpgi/instance/retention.go
+++ b/internal/cnpgi/instance/retention.go
@@ -93,6 +93,8 @@ func (c *CatalogMaintenanceRunnable) cycle(ctx context.Context) (time.Duration, 
 		return 0, err
 	}
 
+	ctx = common.ContextWithProviderOptions(ctx, barmanObjectStore)
+
 	if err := c.maintenance(ctx, &cluster, &barmanObjectStore); err != nil {
 		return 0, err
 	}

--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -109,7 +109,7 @@ func (impl JobHookImpl) Restore(
 		}
 
 		if err := impl.checkBackupDestination(
-			ctx,
+			common.ContextWithProviderOptions(ctx, targetObjectStore),
 			configuration.Cluster,
 			&targetObjectStore.Spec.Configuration,
 			targetObjectStore.Name,
@@ -117,6 +117,8 @@ func (impl JobHookImpl) Restore(
 			return nil, err
 		}
 	}
+
+	ctx = common.ContextWithProviderOptions(ctx, recoveryObjectStore)
 
 	// Detect the backup to recover
 	backup, env, err := loadBackupObjectFromExternalCluster(

--- a/pkg/metadata/doc.go
+++ b/pkg/metadata/doc.go
@@ -1,0 +1,2 @@
+// Package metadata provides metadata utilities for the Barman Cloud plugin
+package metadata

--- a/pkg/metadata/labels_annotations.go
+++ b/pkg/metadata/labels_annotations.go
@@ -1,0 +1,15 @@
+package metadata
+
+// MetadataNamespace is the namespace used for the Barman Cloud plugin metadata
+const MetadataNamespace = "barmancloud.cnpg.io"
+
+const (
+	// UseDefaultAzureCredentialsAnnotationName is an annotation that can be set
+	// on an ObjectStore resource to enable the use DefaultAzureCredentials
+	// to authenticate to Azure. This is meant to be used with inheritFromAzureAD enabled.
+	UseDefaultAzureCredentialsAnnotationName = MetadataNamespace + "/useDefaultAzureCredentials"
+
+	// UseDefaultAzureCredentialsTrueValue is the value for the annotation
+	// barmancloud.cnpg.io/useDefaultAzureCredentials to enable the use of DefaultAzureCredentials
+	UseDefaultAzureCredentialsTrueValue = "true"
+)

--- a/pkg/metadata/labels_annotations.go
+++ b/pkg/metadata/labels_annotations.go
@@ -4,12 +4,12 @@ package metadata
 const MetadataNamespace = "barmancloud.cnpg.io"
 
 const (
-	// UseDefaultAzureCredentialsAnnotationName is an annotation that can be set
-	// on an ObjectStore resource to enable the authentication to Azure via DefaultAzureCredentials.
+	// UseDefaultAzureCredentialAnnotationName is an annotation that can be set
+	// on an ObjectStore resource to enable the authentication to Azure via DefaultAzureCredential.
 	// This is meant to be used with inheritFromAzureAD enabled.
-	UseDefaultAzureCredentialsAnnotationName = MetadataNamespace + "/useDefaultAzureCredentials"
+	UseDefaultAzureCredentialAnnotationName = MetadataNamespace + "/useDefaultAzureCredential"
 
-	// UseDefaultAzureCredentialsTrueValue is the value for the annotation
-	// barmancloud.cnpg.io/useDefaultAzureCredentials to enable the DefaultAzureCredentials auth mechanism.
-	UseDefaultAzureCredentialsTrueValue = "true"
+	// UseDefaultAzureCredentialTrueValue is the value for the annotation
+	// barmancloud.cnpg.io/useDefaultAzureCredential to enable the DefaultAzureCredentials auth mechanism.
+	UseDefaultAzureCredentialTrueValue = "true"
 )

--- a/pkg/metadata/labels_annotations.go
+++ b/pkg/metadata/labels_annotations.go
@@ -5,11 +5,11 @@ const MetadataNamespace = "barmancloud.cnpg.io"
 
 const (
 	// UseDefaultAzureCredentialsAnnotationName is an annotation that can be set
-	// on an ObjectStore resource to enable the use DefaultAzureCredentials
-	// to authenticate to Azure. This is meant to be used with inheritFromAzureAD enabled.
+	// on an ObjectStore resource to enable the authentication to Azure via DefaultAzureCredentials.
+	// This is meant to be used with inheritFromAzureAD enabled.
 	UseDefaultAzureCredentialsAnnotationName = MetadataNamespace + "/useDefaultAzureCredentials"
 
 	// UseDefaultAzureCredentialsTrueValue is the value for the annotation
-	// barmancloud.cnpg.io/useDefaultAzureCredentials to enable the use of DefaultAzureCredentials
+	// barmancloud.cnpg.io/useDefaultAzureCredentials to enable the DefaultAzureCredentials auth mechanism.
 	UseDefaultAzureCredentialsTrueValue = "true"
 )

--- a/web/docs/object_stores.md
+++ b/web/docs/object_stores.md
@@ -233,7 +233,7 @@ Barman Cloud supports the following authentication methods:
 - Storage Account Name + [Access Key](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
 - Storage Account Name + [SAS Token](https://learn.microsoft.com/en-us/azure/storage/blobs/sas-service-create)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)
-- [Azure Default Credentials](https://learn.microsoft.com/en-us/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview)
+- [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview)
 
 ### Azure AD Workload Identity
 
@@ -253,10 +253,11 @@ spec:
   [...]
 ```
 
-### Azure Default Credentials
+### DefaultAzureCredential
 
-To authenticate using Azure Default Credentials, set the annotation
-`barmancloud.cnpg.io/useDefaultAzureCredentials="true"` on the ObjectStore:
+To authenticate using `DefaultAzureCredential`, set the annotation
+`barmancloud.cnpg.io/useDefaultAzureCredential="true"` on the ObjectStore in
+conjunction with the `.spec.configuration.inheritFromAzureAD` option:
 
 ```yaml
 apiVersion: barmancloud.cnpg.io/v1
@@ -264,7 +265,7 @@ kind: ObjectStore
 metadata:
   name: azure-store
   annotations:
-    barmancloud.cnpg.io/useDefaultAzureCredentials: "true"
+    barmancloud.cnpg.io/useDefaultAzureCredential: "true"
 spec:
   configuration:
     destinationPath: "<destination path here>"

--- a/web/docs/object_stores.md
+++ b/web/docs/object_stores.md
@@ -233,6 +233,7 @@ Barman Cloud supports the following authentication methods:
 - Storage Account Name + [Access Key](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage)
 - Storage Account Name + [SAS Token](https://learn.microsoft.com/en-us/azure/storage/blobs/sas-service-create)
 - [Azure AD Workload Identity](https://azure.github.io/azure-workload-identity/docs/introduction.html)
+- [Azure Default Credentials](https://learn.microsoft.com/en-us/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview)
 
 ### Azure AD Workload Identity
 
@@ -244,6 +245,26 @@ apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
   name: azure-store
+spec:
+  configuration:
+    destinationPath: "<destination path here>"
+    azureCredentials:
+      inheritFromAzureAD: true
+  [...]
+```
+
+### Azure Default Credentials
+
+To authenticate using Azure Default Credentials, set the annotation
+`barmancloud.cnpg.io/useDefaultAzureCredentials="true"` on the ObjectStore:
+
+```yaml
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: azure-store
+  annotations:
+    barmancloud.cnpg.io/useDefaultAzureCredentials: "true"
 spec:
   configuration:
     destinationPath: "<destination path here>"


### PR DESCRIPTION
Add support for authenticating to Azure via `DefaultAzureCredential`. 
If the annotation `barmancloud.cnpg.io/useDefaultAzureCredentials="true"` is detected on the ObjectStore, in addition of setting the value `.spec.configuration.azureCredentials.inheritFromAzureAD: true`, the barman-cloud commands will be executed to use `DefaultAzureCredential`.

Fixes #662