### PR TITLE
fix(deploy): added certificate.privateKey.rotationPolicy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1055,6 +1055,8 @@ spec:
   secretName: barman-cloud-client-tls
   usages:
   - client auth
+  privateKey:
+    rotationPolicy: Always
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -1075,6 +1077,8 @@ spec:
   secretName: barman-cloud-server-tls
   usages:
   - server auth
+  privateKey:
+    rotationPolicy: Always
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer


### PR DESCRIPTION
In certmanager v18 the default value of private key rotation policy [has changed](https://cert-manager.io/docs/usage/certificate/#issuance-behavior-rotation-of-the-private-key)

And the webhook triggers a warning if it's not specified explicitly:

```
Warning: spec.privateKey.rotationPolicy: In cert-manager >= v1.18.0, the default value changed from `Never` to `Always`.
```

This PR adds the explicit value of `Always`.