### PR TITLE
fix(targetTime): treat RFC3339-like timestamps without timezone as UTC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cloudnative-pg/cloudnative-pg v1.28.0
 	github.com/cloudnative-pg/cnpg-i v0.3.1
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.2
-	github.com/cloudnative-pg/machinery v0.3.2
+	github.com/cloudnative-pg/machinery v0.3.3
 	github.com/onsi/ginkgo/v2 v2.27.3
 	github.com/onsi/gomega v1.38.3
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/cloudnative-pg/cnpg-i v0.3.1 h1:fKj8NoToWI11HUL2UWYJBpkVzmaTvbs3kDMo7
 github.com/cloudnative-pg/cnpg-i v0.3.1/go.mod h1:glRDiJLJY51FY8ScJIv/OkaGJxFnojJkkNAqSy5XC6s=
 github.com/cloudnative-pg/cnpg-i-machinery v0.4.2 h1:0reS9MtyLYINHXQ/MfxJ9jp39hhBf8e3Qdj+T5Nsq6I=
 github.com/cloudnative-pg/cnpg-i-machinery v0.4.2/go.mod h1:gvrKabgxXq0zGthXGucemDdsxakLEQDMxn43M4HLW30=
-github.com/cloudnative-pg/machinery v0.3.2 h1:jtJZiQ3hHGTTRk21854E84owFqrVvaGvLfBcH4E/WXY=
-github.com/cloudnative-pg/machinery v0.3.2/go.mod h1:RYAYlVKBF5pH4mg+Q8wHjNDyENV9ajbkG41zOEf8DEs=
+github.com/cloudnative-pg/machinery v0.3.3 h1:CaqXqLTJH9RrVv3R/YU0NmFaI/F18HLg2JfH3mQLcDk=
+github.com/cloudnative-pg/machinery v0.3.3/go.mod h1:RYAYlVKBF5pH4mg+Q8wHjNDyENV9ajbkG41zOEf8DEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/web/docs/troubleshooting.md
+++ b/web/docs/troubleshooting.md
@@ -339,7 +339,7 @@ For detailed Barman restore operations and troubleshooting, refer to the
        recovery:
          source: origin
          recoveryTarget:
-           targetTime: "2024-01-15 10:30:00"
+           targetTime: "2024-01-15T10:30:00Z"
 
      externalClusters:
        - name: origin
@@ -357,6 +357,11 @@ For detailed Barman restore operations and troubleshooting, refer to the
    kubectl logs -n <namespace> <cluster-pod> \
      -c plugin-barman-cloud | grep -i wal
    ```
+
+:::note
+RFC 3339 timestamps without an explicit timezone suffix
+(e.g., `2024-01-15T10:30:00`) are interpreted as UTC.
+:::
 
 :::note
 For detailed PITR configuration and WAL management, see the


### PR DESCRIPTION
Update the machinery dependency to include the fix that ensures RFC3339-like timestamps without timezone (e.g., "2024-01-15T10:30:00") are interpreted as UTC.

The documentation has been updated to use a targetTime example with an explicit Z suffix and to clarify that RFC3339-like timestamps without timezone are interpreted as UTC.

Closes #699 