### PR TITLE
docs(targetTime): align documentation with cloudnative-pg

### DIFF
--- a/web/docs/troubleshooting.md
+++ b/web/docs/troubleshooting.md
@@ -359,8 +359,14 @@ For detailed Barman restore operations and troubleshooting, refer to the
    ```
 
 :::note
-RFC 3339 timestamps without an explicit timezone suffix
-(e.g., `2024-01-15T10:30:00`) are interpreted as UTC.
+Timestamps without an explicit timezone suffix
+(e.g., `2024-01-15 10:30:00`) are interpreted as UTC.
+:::
+
+:::warning
+Always specify an explicit timezone in your timestamp to avoid ambiguity.
+For example, use `2024-01-15T10:30:00Z` or `2024-01-15T10:30:00+02:00`
+instead of `2024-01-15 10:30:00`.
 :::
 
 :::note


### PR DESCRIPTION
Follow-up to #700 to align the targetTime documentation with cloudnative-pg standards. The note now covers all timestamp formats (not just RFC 3339) and uses PostgreSQL format in the example to avoid advertising the non-standard RFC3339-like format without timezone. A warning has been added recommending to always specify an explicit timezone to avoid ambiguity.

Related: #699