### PR TITLE
fix(azure): update barman-cloud with Azure validation fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.5
 require (
 	github.com/cert-manager/cert-manager v1.19.2
 	github.com/cloudnative-pg/api v1.28.0
-	github.com/cloudnative-pg/barman-cloud v0.4.0
+	github.com/cloudnative-pg/barman-cloud v0.4.1-0.20251230211524-20b7e0e10b0f
 	github.com/cloudnative-pg/cloudnative-pg v1.28.0
 	github.com/cloudnative-pg/cnpg-i v0.3.1
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.28.0 h1:xElzHliO0eKkVQafkfMhDJo0aIRCmB1ItEt+SGh6B58=
 github.com/cloudnative-pg/api v1.28.0/go.mod h1:puXJBOsEaJd8JLgvCtxgl2TO/ZANap/z7bPepKRUgrk=
-github.com/cloudnative-pg/barman-cloud v0.4.0 h1:V4ajM5yDWq2m+TxmnDtCBGmfMXAxbXr9k7lfR4jM+eE=
-github.com/cloudnative-pg/barman-cloud v0.4.0/go.mod h1:AWdyNP2jvMO1c7eOOwT8kT+QGyK5O7lEBZX12LEZ1Ic=
+github.com/cloudnative-pg/barman-cloud v0.4.1-0.20251230211524-20b7e0e10b0f h1:4/PwIQOwQSTIxuncGRn3pX2V9CRwl7zJNXOVWOMSCCU=
+github.com/cloudnative-pg/barman-cloud v0.4.1-0.20251230211524-20b7e0e10b0f/go.mod h1:qD0NtJOllNQbRB0MaleuHsZjFYaXtXfdg0HbFTbuHn0=
 github.com/cloudnative-pg/cloudnative-pg v1.28.0 h1:vkv0a0ewDSfJOPJrsyUr4uczsxheReAWf/k171V0Dm0=
 github.com/cloudnative-pg/cloudnative-pg v1.28.0/go.mod h1:209fkRR6m0vXUVQ9Q498eAPQqN2UlXECbXXtpGsZz3I=
 github.com/cloudnative-pg/cnpg-i v0.3.1 h1:fKj8NoToWI11HUL2UWYJBpkVzmaTvbs3kDMo7wQF8RU=


### PR DESCRIPTION
This change fixes Azure credentials validation to require a storage account when using explicit credentials such as a storage key or SAS token, and ensures the connection string is mutually exclusive with other authentication parameters.

Closes #705

Related: cloudnative-pg/barman-cloud#177