### PR TITLE
docs(authentication): add disclaimer about authentication methods testing

### DIFF
--- a/web/docs/object_stores.md
+++ b/web/docs/object_stores.md
@@ -29,6 +29,16 @@ the specific object storage provider you are using.
 
 The following sections detail the setup for each.
 
+:::note Authentication Methods
+The Barman Cloud Plugin does not independently test all authentication methods
+supported by `barman-cloud`. The plugin's responsibility is limited to passing
+the provided credentials to `barman-cloud`, which then handles authentication
+according to its own implementation. Users should refer to the
+[Barman Cloud documentation](https://docs.pgbarman.org/release/latest/) to
+verify that their chosen authentication method is supported and properly
+configured.
+:::
+
 ---
 
 ## AWS S3


### PR DESCRIPTION
This PR adds a disclaimer to the object stores documentation clarifying that the Barman Cloud Plugin does not independently test all authentication methods supported by barman-cloud. The plugin's responsibility is limited to passing the provided credentials to barman-cloud, which then handles authentication according to its own implementation.

This documentation change was decided by the maintainers as part of the discussion around Azure Default Credentials support (#662).