### PR TITLE
docs(apidoc): filter Optional markers from validation column

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,7 +86,7 @@ tasks:
       # renovate: datasource=git-refs depName=crd-gen-refs lookupName=https://github.com/cloudnative-pg/daggerverse currentValue=main
       DAGGER_CRDGENREF_SHA: ee59e34a99940e45f87a16177b1d640975b05b74
       # renovate: datasource=go depName=github.com/elastic/crd-ref-docs
-      CRDREFDOCS_VERSION: v0.2.0
+      CRDREFDOCS_VERSION: v0.3.0
     cmds:
       - >
         GITHUB_REF= dagger -s call -m github.com/cloudnative-pg/daggerverse/crd-ref-docs@${DAGGER_CRDGENREF_SHA}

--- a/hack/crd-gen-refs/config.yaml
+++ b/hack/crd-gen-refs/config.yaml
@@ -1,9 +1,6 @@
 processor:
   ignoreGroupVersions:
     - "GVK"
-  customMarkers:
-    - name: "optional"
-      target: field
   ignoreFields:
 #    - "status$"
     - "TypeMeta$"

--- a/hack/crd-gen-refs/markdown/type.tpl
+++ b/hack/crd-gen-refs/markdown/type.tpl
@@ -31,7 +31,7 @@ _Appears in:_
 {{ end -}}
 
 {{ range $type.Members -}}
-| `{{ .Name  }}` _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} | {{ if not .Markers.optional -}}True{{- end }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}} {{ markdownRenderFieldDoc . }} <br />{{ end }} |
+| `{{ .Name  }}` _{{ markdownRenderType .Type }}_ | {{ template "type_members" . }} | {{ if not .Markers.optional -}}True{{- end }} | {{ markdownRenderDefault .Default }} | {{ range .Validation -}}{{- $v := markdownRenderFieldDoc . }}{{- if and $v (ne $v "Optional: \\{\\}") -}} {{ $v }} <br />{{ end }}{{- end }} |
 {{ end -}}
 
 {{ end -}}


### PR DESCRIPTION
The crd-ref-docs tool v0.3.0 started rendering `+optional` Go markers as `Optional: {}` in API documentation's validation column. This appeared as redundant empty JSON objects since the Required column already conveyed this information. The PR updates the documentation template to filter these markers while keeping meaningful validation rules like patterns and enums, and removes unnecessary customMarkers configuration.

Closes #722 