### PR TITLE
ci(e2e): pin emulator versions and fix Azurite compatibility

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,6 +38,15 @@
     {
       customType: 'regex',
       managerFilePatterns: [
+        '\\.go$',
+      ],
+      matchStrings: [
+        '// renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+(?:// Version: (?<currentValue>[^\\s]+?)\\s+)?Image:\\s*"[^@]+@(?<currentDigest>sha256:[a-f0-9]+)"',
+      ],
+    },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
         '/(^docs/config\\.yaml$)/',
       ],
       matchStrings: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,17 @@
   ],
   rebaseWhen: 'never',
   prConcurrentLimit: 5,
+  // Override default ignorePaths to scan test/e2e for emulator image dependencies
+  // Removed: '**/test/**'
+  ignorePaths: [
+    '**/node_modules/**',
+    '**/bower_components/**',
+    '**/vendor/**',
+    '**/examples/**',
+    '**/__tests__/**',
+    '**/tests/**',
+    '**/__fixtures__/**',
+  ],
   lockFileMaintenance: {
     enabled: true,
   },
@@ -28,7 +39,7 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/(^Taskfile\\.yml$)/',
+        '/(^|/)Taskfile\\.yml$/',
       ],
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: currentValue=(?<currentValue>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_SHA\\s*:\\s*["\']?(?<currentDigest>[a-f0-9]+?)["\']?\\s',
@@ -38,16 +49,16 @@
     {
       customType: 'regex',
       managerFilePatterns: [
-        '\\.go$',
+        '/\\.go$/',
       ],
       matchStrings: [
-        '// renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: versioning=(?<versioning>[^\\s]+?))?\\s+(?:// Version: (?<currentValue>[^\\s]+?)\\s+)?Image:\\s*"[^@]+@(?<currentDigest>sha256:[a-f0-9]+)"',
+        '//\\s*renovate:\\s*datasource=(?<datasource>[a-z-.]+?)\\s+depName=(?<depName>[^\\s]+?)(?:\\s+versioning=(?<versioning>[^\\s]+?))?\\s*\\n\\s*//\\s*Version:\\s*(?<currentValue>[^\\s]+?)\\s*\\n\\s*Image:\\s*"[^@]+@(?<currentDigest>sha256:[a-f0-9]+)"',
       ],
     },
     {
       customType: 'regex',
       managerFilePatterns: [
-        '/(^docs/config\\.yaml$)/',
+        '/(^|/)docs/config\\.yaml$/',
       ],
       matchStrings: [
         '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+kubernetesVersion:\\s*["\']?(?<currentValue>.+?)["\']?\\s',

--- a/test/e2e/internal/objectstore/azurite.go
+++ b/test/e2e/internal/objectstore/azurite.go
@@ -74,6 +74,12 @@ func newAzuriteDeployment(namespace, name string) *appsv1.Deployment {
 							// renovate: datasource=docker depName=mcr.microsoft.com/azure-storage/azurite versioning=docker
 							// Version: 3.35.0
 							Image: "mcr.microsoft.com/azure-storage/azurite@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37",
+							Args: []string{
+								"azurite-blob",
+								"--blobHost",
+								"0.0.0.0",
+								"--skipApiVersionCheck",
+							},
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 10000,

--- a/test/e2e/internal/objectstore/azurite.go
+++ b/test/e2e/internal/objectstore/azurite.go
@@ -71,8 +71,9 @@ func newAzuriteDeployment(namespace, name string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name: name,
-							// TODO: renovate the image
-							Image: "mcr.microsoft.com/azure-storage/azurite",
+							// renovate: datasource=docker depName=mcr.microsoft.com/azure-storage/azurite versioning=docker
+							// Version: 3.35.0
+							Image: "mcr.microsoft.com/azure-storage/azurite@sha256:647c63a91102a9d8e8000aab803436e1fc85fbb285e7ce830a82ee5d6661cf37",
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 10000,

--- a/test/e2e/internal/objectstore/fakegcsserver.go
+++ b/test/e2e/internal/objectstore/fakegcsserver.go
@@ -71,7 +71,9 @@ func newGCSDeployment(namespace, name string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name:  name,
-							Image: "fsouza/fake-gcs-server:latest",
+							// renovate: datasource=docker depName=fsouza/fake-gcs-server versioning=docker
+							// Version: 1.52.3
+							Image: "fsouza/fake-gcs-server@sha256:666f86b873120818b10a5e68d99401422fcf8b00c1f27fe89599c35236f48b4c",
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 4443,

--- a/test/e2e/internal/objectstore/minio.go
+++ b/test/e2e/internal/objectstore/minio.go
@@ -71,8 +71,9 @@ func newMinioDeployment(namespace, name string) *appsv1.Deployment {
 					Containers: []corev1.Container{
 						{
 							Name: name,
-							// TODO: renovate the image
-							Image: "minio/minio:latest",
+							// renovate: datasource=docker depName=minio/minio versioning=docker
+							// Version: RELEASE.2025-09-07T16-13-09Z
+							Image: "minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
 							Args:  []string{"server", "/data"},
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
Pin all e2e test emulator images to specific SHA256 digests to ensure immutability and prevent unexpected breakage from upstream changes.

The three emulators (Azurite for Azure, MinIO for S3, and fake-gcs-server for GCS) were previously using the :latest tag, which could cause test failures when new versions with breaking changes or bugs were released.

Using SHA256 digests instead of version tags provides immutability (ensures we always pull the exact same image), transparency (easy to verify what's running via digest comparison), and Renovate compatibility (can still track and propose updates). All pinned SHAs match the current :latest tag, confirming we're using the same images that were previously tested.

Updated Renovate configuration to track digest-based updates while preserving version information in comments for human readability. Fixed Renovate to scan test directories and handle multi-line regex patterns for .go files.

Also fixed Azurite compatibility issue by adding the --skipApiVersionCheck flag. Tests were failing because the PostgreSQL container images install Python dependencies without version pinning, which resulted in azure-storage-blob 12.28.0 (released January 6, 2026) being installed. This version uses API version 2026-02-06 which Azurite 3.35.0 doesn't support yet. The flag allows Azurite to accept any API version in the test environment.

Note that MinIO is now in maintenance mode and will not receive further updates, but it has been included for completeness.