### PR TITLE
test(e2e): reduce test output verbosity with k3s logging controls

### DIFF
--- a/dagger/e2e/dagger.json
+++ b/dagger/e2e/dagger.json
@@ -12,8 +12,9 @@
     },
     {
       "name": "k3s",
-      "source": "github.com/marcosnils/daggerverse/k3s@k3s/v0.1.10",
-      "pin": "28eea1fcf3b6ecb38a628186107760acd717442f"
+      "source": "github.com/mnencia/daggerverse/k3s@feat/log-verbosity-control",
+      "pin": "76b0bc3fa496fe98c63c8b3db9013ab49a47705e"
     }
-  ]
+  ],
+  "disableDefaultFunctionCaching": true
 }


### PR DESCRIPTION
This PR uses a fork of the k3s dagger module that adds:
1. Optional debug parameter (defaults to false) to disable k3s server debug output
2. Optional kubeletVerbosity parameter (defaults to 1) to control kubelet logging

This significantly improves readability of e2e test output by eliminating verbose logs like:
- K3s server: certificate generation, database initialization, control plane startup
- Kubelet: container operations, volume cleanup, pod lifecycle events

The kubelet verbosity is controlled via kubelet configuration file placed in `/var/lib/rancher/k3s/agent/etc/kubelet.conf.d/99-logging.conf`. K3s merges config files alphabetically, so this overrides the default `00-k3s-defaults.conf` settings before kubelet initializes, avoiding the logging configuration immutability issue.

The fork will be used until these changes are merged upstream.