### PR TITLE
fix(security): harden GitHub Actions workflows against expression injection

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,10 +51,12 @@ jobs:
       # We use a GitHub token with write permissions to create the release,
       # otherwise we won't be able to trigger a new run when pushing on main.
       - name: Run release-please
+        env:
+          REPO_URL: ${{ github.repository }}
         run: |
           npx release-please release-pr \
             --token="${{ secrets.REPO_PAT }}" \
-            --repo-url="${{ github.repository }}"
+            --repo-url="${REPO_URL}"
           npx release-please github-release \
             --token="${{ secrets.REPO_PAT }}" \
-            --repo-url="${{ github.repository }}"
+            --repo-url="${REPO_URL}"


### PR DESCRIPTION
Move `${{ }}` expressions from `run:` blocks into step-level `env:` blocks, then reference them as properly-quoted shell variables.

Part of cloudnative-pg/cloudnative-pg#10113

Assisted-by: Claude Opus 4.6