### PR TITLE
fix(metrics): announce sidecar injection capability

### DIFF
--- a/internal/cnpgi/operator/identity.go
+++ b/internal/cnpgi/operator/identity.go
@@ -62,6 +62,13 @@ func (i IdentityImplementation) GetPluginCapabilities(
 					},
 				},
 			},
+			{
+				Type: &identity.PluginCapability_Service_{
+					Service: &identity.PluginCapability_Service{
+						Type: identity.PluginCapability_Service_TYPE_INSTANCE_SIDECAR_INJECTION,
+					},
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
The operator was not announcing the `TYPE_INSTANCE_SIDECAR_INJECTION` capability, so the CNPG operator did not consider the plugin enabled for instance pods. As a result, the instance manager never queried the plugin's metrics endpoint, and the new `barman_cloud_cloudnative_pg_io_*` metrics were missing entirely.

This bug was masked when `isWALArchiver` was set to `true` in the plugin configuration, because the [backward compatibility code](https://github.com/cloudnative-pg/cloudnative-pg/blob/122de17520b21f74c1619fd2951fb977227f8ea5/pkg/management/postgres/metrics/collector.go#L743) in CNPG would mark the plugin as enabled as a side-effect. Users with `isWALArchiver: false` (or omitted) never saw the new metrics.

The fix adds `TYPE_INSTANCE_SIDECAR_INJECTION` to `GetPluginCapabilities()`, which is already backed by the existing `OperatorLifecycleServer` implementation that handles pod mutation and sidecar injection via lifecycle hooks.

Fixes #682