### PR TITLE
chore(ci): read Go version from go.mod toolchain directive

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,6 +6,8 @@ output: prefixed
 
 # Variables that are shared across tasks.
 vars:
+  GO_VERSION:
+    sh: sed -n 's/^toolchain go//p' go.mod
   # renovate: datasource=docker depName=kindest/node versioning=semver
   E2E_KUBERNETES_VERSION: v1.35.1
   E2E_CLUSTER_NAME: barman-cloud-plugin-e2e-{{.E2E_KUBERNETES_VERSION}}
@@ -128,8 +130,6 @@ tasks:
   go-test:
     desc: Run go test
     env:
-      # renovate: datasource=docker depName=golang versioning=semver
-      GOLANG_IMAGE_VERSION: 1.26.1
       # renovate: datasource=git-refs depname=kubernetes packageName=https://github.com/kubernetes/kubernetes versioning=semver
       K8S_VERSION: 1.31.0
       # renovate: datasource=git-refs depName=controller-runtime packageName=https://github.com/kubernetes-sigs/controller-runtime versioning=semver
@@ -137,7 +137,7 @@ tasks:
     cmds:
       - >
         GITHUB_REF= dagger -s call -m ./dagger/gotest
-        --go-version ${GOLANG_IMAGE_VERSION}
+        --go-version {{.GO_VERSION}}
         --kube-version ${K8S_VERSION}
         --setup-envtest-version ${SETUP_ENVTEST_VERSION}
         unit-test --src .
@@ -231,7 +231,7 @@ tasks:
     cmds:
       - >
         GITHUB_REF= dagger -s call -m github.com/purpleclay/daggerverse/docker@${DAGGER_DOCKER_SHA}
-        build --dir . --file containers/Dockerfile.plugin --platform linux/amd64
+        build --dir . --file containers/Dockerfile.plugin --args GO_VERSION={{.GO_VERSION}} --platform linux/amd64
         publish --ref {{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}/plugin-barman-cloud --tags testing
 
   # We build an image and push it to a local registry.
@@ -248,7 +248,7 @@ tasks:
     cmds:
       - >
         GITHUB_REF= dagger -s call -m github.com/purpleclay/daggerverse/docker@${DAGGER_DOCKER_SHA}
-        build --dir . --file containers/Dockerfile.sidecar --platform linux/amd64
+        build --dir . --file containers/Dockerfile.sidecar --args GO_VERSION={{.GO_VERSION}} --platform linux/amd64
         publish --ref {{ .REGISTRY_NAME }}:{{ .REGISTRY_PORT }}/sidecar-barman-cloud --tags testing
 
   build-images:
@@ -305,8 +305,6 @@ tasks:
       - build-images
       - start-kind-cluster
     vars:
-      # renovate: datasource=docker depName=golang versioning=semver
-      GOLANG_IMAGE_VERSION: 1.26.1
       KUBECONFIG_PATH:
         sh: mktemp -t kubeconfig-XXXXX
     env:
@@ -317,15 +315,12 @@ tasks:
         GITHUB_REF= dagger call -m  dagger/e2e/ run
         --source .
         --kubeconfig {{.KUBECONFIG_PATH}}
-        --go-version {{ .GOLANG_IMAGE_VERSION }}
+        --go-version {{.GO_VERSION}}
 
   e2e-ephemeral:
     desc: Run e2e tests in an ephemeral k3s cluster
     deps:
       - build-images
-    vars:
-      # renovate: datasource=docker depName=golang versioning=semver
-      GOLANG_IMAGE_VERSION: 1.26.1
     env:
       _EXPERIMENTAL_DAGGER_RUNNER_HOST: docker-container://{{ .DAGGER_ENGINE_CONTAINER_NAME }}
     cmds:
@@ -334,7 +329,7 @@ tasks:
         --source .
         --ca certs/ca.pem
         --registry {{.REGISTRY_NAME}}:{{.REGISTRY_PORT}}
-        --go-version {{ .GOLANG_IMAGE_VERSION }}
+        --go-version {{.GO_VERSION}}
 
   ci:
     desc: Run the CI pipeline
@@ -373,12 +368,12 @@ tasks:
       - >
         dagger call -m github.com/purpleclay/daggerverse/docker@${DAGGER_DOCKER_SHA}
         --registry ghcr.io --username $REGISTRY_USER --password env:REGISTRY_PASSWORD
-        build --dir . --file containers/Dockerfile.plugin --platform linux/amd64 --platform linux/arm64
+        build --dir . --file containers/Dockerfile.plugin --args GO_VERSION={{.GO_VERSION}} --platform linux/amd64 --platform linux/arm64
         publish --ref {{.PLUGIN_IMAGE_NAME}} --tags {{.IMAGE_VERSION}}
       - >
         dagger call -m github.com/purpleclay/daggerverse/docker@${DAGGER_DOCKER_SHA}
         --registry ghcr.io --username $REGISTRY_USER --password env:REGISTRY_PASSWORD
-        build --dir . --file containers/Dockerfile.sidecar --platform linux/amd64 --platform linux/arm64
+        build --dir . --file containers/Dockerfile.sidecar --args GO_VERSION={{.GO_VERSION}} --platform linux/amd64 --platform linux/arm64
         publish --ref {{.SIDECAR_IMAGE_NAME}} --tags {{.IMAGE_VERSION}}
 
   controller-gen:

--- a/containers/Dockerfile.plugin
+++ b/containers/Dockerfile.plugin
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.1 AS gobuilder
+# GO_VERSION must be passed as a build arg (read from go.mod toolchain directive by Taskfile)
+ARG GO_VERSION
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS gobuilder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/containers/Dockerfile.sidecar
+++ b/containers/Dockerfile.sidecar
@@ -5,7 +5,9 @@
 # Both components are built before going into a distroless container
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.1 AS gobuilder
+# GO_VERSION must be passed as a build arg (read from go.mod toolchain directive by Taskfile)
+ARG GO_VERSION
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS gobuilder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Replace hardcoded Go version across the Taskfile and Dockerfiles with a single `GO_VERSION` variable extracted from go.mod's `toolchain` directive. This makes go.mod the single source of truth for the Go version, removing the need to keep 3 Taskfile tasks and 2 Dockerfiles in sync via Renovate's custom regex manager.

Mirrors cloudnative-pg/cloudnative-pg@0ad04368cc902b4d9c80088d9a8c20b6d3889f12 for this repository.