### PR TITLE
test(e2e): use correct image name in kustomize overlay

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - service.yaml
 - ../config/crd
 - ../config/rbac
+# If you change newName, update the e2e overlay in test/e2e/e2e_suite_test.go too.
 images:
 - name: plugin-barman-cloud
   newName: ghcr.io/cloudnative-pg/plugin-barman-cloud-testing

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -57,9 +57,11 @@ var _ = SynchronizedBeforeSuite(func(ctx SpecContext) []byte {
 	const barmanCloudKustomizationPath = "./kustomize/kubernetes/"
 	barmanCloudKustomization := &kustomizeTypes.Kustomization{
 		Resources: []string{barmanCloudKustomizationPath},
+		// Override the image from the base kustomization (kubernetes/kustomization.yaml)
+		// with the locally-built one. The Name must match the newName in the base.
 		Images: []kustomizeTypes.Image{
 			{
-				Name:    "plugin-barman-cloud",
+				Name:    "ghcr.io/cloudnative-pg/plugin-barman-cloud-testing",
 				NewName: "registry.barman-cloud-plugin:5000/plugin-barman-cloud",
 				NewTag:  "testing",
 			},

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -59,7 +59,7 @@ var _ = SynchronizedBeforeSuite(func(ctx SpecContext) []byte {
 		Resources: []string{barmanCloudKustomizationPath},
 		Images: []kustomizeTypes.Image{
 			{
-				Name:    "docker.io/library/plugin-barman-cloud",
+				Name:    "plugin-barman-cloud",
 				NewName: "registry.barman-cloud-plugin:5000/plugin-barman-cloud",
 				NewTag:  "testing",
 			},


### PR DESCRIPTION
The e2e kustomize overlay tried to match
`docker.io/library/plugin-barman-cloud` but the base kustomization at
`kubernetes/kustomization.yaml` already transforms the bare
`plugin-barman-cloud` image to the GHCR name. The overlay must match
the base's output (`ghcr.io/cloudnative-pg/plugin-barman-cloud-testing`)
to override it.

Broken since b7daaac (#89) changed the base kustomization's newName
from `docker.io/library/plugin-barman-cloud` to the GHCR image without
updating the e2e overlay.

Closes #840