### PR TITLE
fix(restore): use custom CNPG group and version for scheme registration

### DIFF
--- a/internal/cmd/restore/main.go
+++ b/internal/cmd/restore/main.go
@@ -57,6 +57,8 @@ func NewCmd() *cobra.Command {
 	_ = viper.BindEnv("pod-name", "POD_NAME")
 	_ = viper.BindEnv("pgdata", "PGDATA")
 	_ = viper.BindEnv("spool-directory", "SPOOL_DIRECTORY")
+	_ = viper.BindEnv("custom-cnpg-group", "CUSTOM_CNPG_GROUP")
+	_ = viper.BindEnv("custom-cnpg-version", "CUSTOM_CNPG_VERSION")
 
 	return cmd
 }

--- a/internal/cnpgi/common/scheme.go
+++ b/internal/cnpgi/common/scheme.go
@@ -1,0 +1,67 @@
+/*
+Copyright © contributors to CloudNativePG, established as
+CloudNativePG a Series of LF Projects, LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package common
+
+import (
+	"context"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	"github.com/cloudnative-pg/machinery/pkg/log"
+	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+
+	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+)
+
+// GenerateScheme creates a runtime.Scheme object with all the
+// definition needed to support the sidecar. This allows
+// the plugin to be used in every CNPG-based operator.
+func GenerateScheme(ctx context.Context) *runtime.Scheme {
+	result := runtime.NewScheme()
+
+	utilruntime.Must(barmancloudv1.AddToScheme(result))
+	utilruntime.Must(clientgoscheme.AddToScheme(result))
+
+	cnpgGroup := viper.GetString("custom-cnpg-group")
+	cnpgVersion := viper.GetString("custom-cnpg-version")
+	if len(cnpgGroup) == 0 {
+		cnpgGroup = cnpgv1.SchemeGroupVersion.Group
+	}
+	if len(cnpgVersion) == 0 {
+		cnpgVersion = cnpgv1.SchemeGroupVersion.Version
+	}
+
+	// Proceed with custom registration of the CNPG scheme
+	schemeGroupVersion := schema.GroupVersion{Group: cnpgGroup, Version: cnpgVersion}
+	schemeBuilder := &scheme.Builder{GroupVersion: schemeGroupVersion}
+	schemeBuilder.Register(&cnpgv1.Cluster{}, &cnpgv1.ClusterList{})
+	schemeBuilder.Register(&cnpgv1.Backup{}, &cnpgv1.BackupList{})
+	schemeBuilder.Register(&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{})
+	utilruntime.Must(schemeBuilder.AddToScheme(result))
+
+	schemeLog := log.FromContext(ctx)
+	schemeLog.Info("CNPG types registration", "schemeGroupVersion", schemeGroupVersion)
+
+	return result
+}

--- a/internal/cnpgi/instance/manager.go
+++ b/internal/cnpgi/instance/manager.go
@@ -27,22 +27,18 @@ import (
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
 	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/common"
 	extendedclient "github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/instance/internal/client"
 )
 
 // Start starts the sidecar informers and CNPG-i server
 func Start(ctx context.Context) error {
-	scheme := generateScheme(ctx)
+	scheme := common.GenerateScheme(ctx)
 
 	setupLog := log.FromContext(ctx)
 	setupLog.Info("Starting barman cloud instance plugin")
@@ -117,36 +113,4 @@ func Start(ctx context.Context) error {
 	}
 
 	return nil
-}
-
-// generateScheme creates a runtime.Scheme object with all the
-// definition needed to support the sidecar. This allows
-// the plugin to be used in every CNPG-based operator.
-func generateScheme(ctx context.Context) *runtime.Scheme {
-	result := runtime.NewScheme()
-
-	utilruntime.Must(barmancloudv1.AddToScheme(result))
-	utilruntime.Must(clientgoscheme.AddToScheme(result))
-
-	cnpgGroup := viper.GetString("custom-cnpg-group")
-	cnpgVersion := viper.GetString("custom-cnpg-version")
-	if len(cnpgGroup) == 0 {
-		cnpgGroup = cnpgv1.SchemeGroupVersion.Group
-	}
-	if len(cnpgVersion) == 0 {
-		cnpgVersion = cnpgv1.SchemeGroupVersion.Version
-	}
-
-	// Proceed with custom registration of the CNPG scheme
-	schemeGroupVersion := schema.GroupVersion{Group: cnpgGroup, Version: cnpgVersion}
-	schemeBuilder := &scheme.Builder{GroupVersion: schemeGroupVersion}
-	schemeBuilder.Register(&cnpgv1.Cluster{}, &cnpgv1.ClusterList{})
-	schemeBuilder.Register(&cnpgv1.Backup{}, &cnpgv1.BackupList{})
-	schemeBuilder.Register(&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{})
-	utilruntime.Must(schemeBuilder.AddToScheme(result))
-
-	schemeLog := log.FromContext(ctx)
-	schemeLog.Info("CNPG types registration", "schemeGroupVersion", schemeGroupVersion)
-
-	return result
 }

--- a/internal/cnpgi/restore/manager.go
+++ b/internal/cnpgi/restore/manager.go
@@ -22,26 +22,15 @@ package restore
 import (
 	"context"
 
-	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	barmancloudv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/cloudnative-pg/plugin-barman-cloud/internal/cnpgi/common"
 )
-
-var scheme = runtime.NewScheme()
-
-func init() {
-	utilruntime.Must(barmancloudv1.AddToScheme(scheme))
-	utilruntime.Must(cnpgv1.AddToScheme(scheme))
-	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
-}
 
 // Start starts the sidecar informers and CNPG-i server
 func Start(ctx context.Context) error {
@@ -49,7 +38,7 @@ func Start(ctx context.Context) error {
 	setupLog.Info("Starting barman cloud instance plugin")
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
+		Scheme: common.GenerateScheme(ctx),
 		Client: client.Options{
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{


### PR DESCRIPTION
The restore manager used a hardcoded scheme registration that ignored CUSTOM_CNPG_GROUP and CUSTOM_CNPG_VERSION, causing restore jobs to fail under non-standard CNPG API groups.

Extract `generateScheme()` into `common.GenerateScheme()` and use it from both instance and restore managers.