### PR TITLE
fix: add lz4 compression support for base backups

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -15,6 +15,7 @@ DigitalOcean
 Docusaurus
 EDB
 EKS
+EnterpriseDB
 Enum
 EnvVar
 GCP
@@ -76,6 +77,7 @@ backends
 barmanObjectName
 barmanObjectStore
 barmancloud
+benchmarked
 boto
 bzip
 cd

--- a/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+++ b/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
@@ -144,10 +144,11 @@ spec:
                         description: |-
                           Compress a backup file (a tar file per tablespace) while streaming it
                           to the object store. Available options are empty string (no
-                          compression, default), `gzip`, `bzip2`, and `snappy`.
+                          compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
                         enum:
                         - bzip2
                         - gzip
+                        - lz4
                         - snappy
                         type: string
                       encryption:

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.2
 require (
 	github.com/cert-manager/cert-manager v1.20.2
 	github.com/cloudnative-pg/api v1.29.0
-	github.com/cloudnative-pg/barman-cloud v0.5.0
+	github.com/cloudnative-pg/barman-cloud v0.5.1
 	github.com/cloudnative-pg/cloudnative-pg v1.29.0
 	github.com/cloudnative-pg/cnpg-i v0.5.0
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.2
@@ -140,5 +140,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/cloudnative-pg/barman-cloud => github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690

--- a/go.mod
+++ b/go.mod
@@ -140,3 +140,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/cloudnative-pg/barman-cloud => github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.29.0 h1:mNx6yJ5qi+Xrjs0NYrUy6V4MlXBkVJxGKwvTJZIuTX4=
 github.com/cloudnative-pg/api v1.29.0/go.mod h1:bF3HI8UVVcllZ7M8CfBufnb+Us8FyQArhD+4qtX0qhM=
-github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690 h1:QQGZQQByCDl/KJTIMaYHjdWNVuSNYPOPVxWy52NAFag=
-github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
+github.com/cloudnative-pg/barman-cloud v0.5.1 h1:vjkXrrxo2DQXHT9u9usqhtaHiPZ/lTfDVs/pIWYTepQ=
+github.com/cloudnative-pg/barman-cloud v0.5.1/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
 github.com/cloudnative-pg/cloudnative-pg v1.29.0 h1:49Dm8+y4va7RODspJjeaK8uMWP3OGAD0gMsxhjm16Mo=
 github.com/cloudnative-pg/cloudnative-pg v1.29.0/go.mod h1:0Sgb/50VyaCnQm3IbWqgnhQG8Kb6mgqo8Jo1J+KtkSI=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.29.0 h1:mNx6yJ5qi+Xrjs0NYrUy6V4MlXBkVJxGKwvTJZIuTX4=
 github.com/cloudnative-pg/api v1.29.0/go.mod h1:bF3HI8UVVcllZ7M8CfBufnb+Us8FyQArhD+4qtX0qhM=
-github.com/cloudnative-pg/barman-cloud v0.5.0 h1:DykSaX4o7ee2vyu5FQoG1RJsntHd+EIttIKZbJPlB1Q=
-github.com/cloudnative-pg/barman-cloud v0.5.0/go.mod h1:SO2HzLa+GWlSIpGyxnISoJAFPIcaa/qDa33Bb3jefac=
+github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690 h1:QQGZQQByCDl/KJTIMaYHjdWNVuSNYPOPVxWy52NAFag=
+github.com/cloudnative-pg/barman-cloud v0.5.1-0.20260421102124-68d21f378690/go.mod h1:XPc5IUFP1y4cZX1sg+Pd8j9V4tmUEVnv3BGCpfQOOg8=
 github.com/cloudnative-pg/cloudnative-pg v1.29.0 h1:49Dm8+y4va7RODspJjeaK8uMWP3OGAD0gMsxhjm16Mo=
 github.com/cloudnative-pg/cloudnative-pg v1.29.0/go.mod h1:0Sgb/50VyaCnQm3IbWqgnhQG8Kb6mgqo8Jo1J+KtkSI=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -143,10 +143,11 @@ spec:
                         description: |-
                           Compress a backup file (a tar file per tablespace) while streaming it
                           to the object store. Available options are empty string (no
-                          compression, default), `gzip`, `bzip2`, and `snappy`.
+                          compression, default), `gzip`, `bzip2`, `lz4`, and `snappy`.
                         enum:
                         - bzip2
                         - gzip
+                        - lz4
                         - snappy
                         type: string
                       encryption:

--- a/web/docs/compression.md
+++ b/web/docs/compression.md
@@ -15,7 +15,7 @@ for space, speed, or a balance of both.
 
 - `bzip2`
 - `gzip`
-- `lz4` (WAL only)
+- `lz4`
 - `snappy`
 - `xz` (WAL only)
 - `zstd` (WAL only)
@@ -41,3 +41,5 @@ network throughput.
 | bzip2       | 25,404           | 13,886            | 395                    | 67                   | 5.9:1 |
 | gzip        | 116,281          | 3,077             | 395                    | 91                   | 4.3:1 |
 | snappy      | 8,134            | 8,341             | 395                    | 166                  | 2.4:1 |
+
+Numbers come from a 2021 Barman proof of concept ([EnterpriseDB/barman#344](https://github.com/EnterpriseDB/barman/issues/344#issuecomment-992547396)), which predates `lz4` support for base backups. `lz4` is not yet benchmarked.


### PR DESCRIPTION
Upgrade barman-cloud library to v0.5.1 which includes lz4 support for
base backups. Update CRD schema and manifest to expose lz4 as a valid
compression option, and clarify docs that lz4 is no longer WAL-only.

Closes #867