### PR TITLE
fix(docs): update broken link to CloudNativePG documentation

### DIFF
--- a/web/docs/usage.md
+++ b/web/docs/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.10.0/usage.md
+++ b/web/versioned_docs/version-0.10.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.11.0/usage.md
+++ b/web/versioned_docs/version-0.11.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.12.0/usage.md
+++ b/web/versioned_docs/version-0.12.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.4.0/usage.md
+++ b/web/versioned_docs/version-0.4.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.4.1/usage.md
+++ b/web/versioned_docs/version-0.4.1/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.5.0/usage.md
+++ b/web/versioned_docs/version-0.5.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.6.0/usage.md
+++ b/web/versioned_docs/version-0.6.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.7.0/usage.md
+++ b/web/versioned_docs/version-0.7.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.8.0/usage.md
+++ b/web/versioned_docs/version-0.8.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important

--- a/web/versioned_docs/version-0.9.0/usage.md
+++ b/web/versioned_docs/version-0.9.0/usage.md
@@ -46,7 +46,7 @@ spec:
 
 The `.spec.configuration` schema follows the same format as the
 [in-tree barman-cloud support](https://pkg.go.dev/github.com/cloudnative-pg/barman-cloud/pkg/api#BarmanObjectStoreConfiguration).
-Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/preview/backup_barmanobjectstore/)
+Refer to [the CloudNativePG documentation](https://cloudnative-pg.io/documentation/current/appendixes/backup_barmanobjectstore/)
 for additional details.
 
 :::important


### PR DESCRIPTION
The BarmanObjectStore reference page moved into the appendixes section of the CloudNativePG documentation, so the previous URL returns 404. Update the link across the Dev docs and every versioned release.

Closes #729