### PR TITLE
feat: pass additionalCommandArgs to barman-cloud-restore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.3
 require (
 	github.com/cert-manager/cert-manager v1.20.2
 	github.com/cloudnative-pg/api v1.29.1
-	github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260529020047-bb683bf8d82a
+	github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260603073812-213211ec5e6f
 	github.com/cloudnative-pg/cloudnative-pg v1.29.1
 	github.com/cloudnative-pg/cnpg-i v0.5.0
 	github.com/cloudnative-pg/cnpg-i-machinery v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,10 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudnative-pg/api v1.29.1 h1:FWr8S7EQeOfdhYXyr2cof8wUXLARZiiQt5Qa6ltED7w=
 github.com/cloudnative-pg/api v1.29.1/go.mod h1:QtWF3yzSvIfORMHaSkPAk/o3bhCJwEHJgN3riyRiz3o=
-github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260529020047-bb683bf8d82a h1:u2Ykj9oCJlJw/xxiCXjG+svTmpaHMcaW6kGNdHdertk=
-github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260529020047-bb683bf8d82a/go.mod h1:DACs5rdlMIQ7mUOpJVBRTrbf+d7OGyMOLsFUEMJ2JV8=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260513095406-dac43abc6cf6 h1:FxIX5u8Kf1aJQnmW/5eRo+1hx/okApecnIJAmvliaJ8=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260513095406-dac43abc6cf6/go.mod h1:VrubJGTgO94O2+m4EX68/wlbDmluc6ITL/VjTcMN3H4=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260603073812-213211ec5e6f h1:37XPQQ7PY1tffCXS4QuRK7eSDIzn6oeF8h3cIteN2SE=
+github.com/cloudnative-pg/barman-cloud v0.5.2-0.20260603073812-213211ec5e6f/go.mod h1:jCaMsQwJJ0f/49TIdSad1Ayjv52IoJXMZBhozqilY/g=
 github.com/cloudnative-pg/cloudnative-pg v1.29.1 h1:ZNEt1TMlnQKXI1kho2UqQuqdfvIvjGln4kN7C1lsmGA=
 github.com/cloudnative-pg/cloudnative-pg v1.29.1/go.mod h1:Sbgx9jVmkle4/gR2U5JHrzDd74sRPOBHDtPkvncg5v8=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=

--- a/internal/cnpgi/restore/restore.go
+++ b/internal/cnpgi/restore/restore.go
@@ -181,6 +181,9 @@ func (impl JobHookImpl) restoreDataDir(
 	if backup.Status.EndpointURL != "" {
 		options = append(options, "--endpoint-url", backup.Status.EndpointURL)
 	}
+
+	options = barmanConfiguration.Data.AppendRestoreAdditionalCommandArgs(options)
+
 	options = append(options, backup.Status.DestinationPath)
 	options = append(options, backup.Status.ServerName)
 	options = append(options, backup.Status.BackupID)

--- a/web/docs/misc.md
+++ b/web/docs/misc.md
@@ -43,8 +43,9 @@ configuration.
 - `.spec.configuration.wal.archiveAdditionalCommandArgs`: for `barman-cloud-wal-archive`
 - `.spec.configuration.wal.restoreAdditionalCommandArgs`: for `barman-cloud-wal-restore`
 
-Each field accepts a list of string arguments. If an argument is already
-configured elsewhere in the plugin, the duplicate will be ignored.
+Each field accepts a list of string arguments. If an argument conflicts with
+one already set by the plugin, the user-provided value will be ignored. These
+fields are intended to pass options the plugin does not configure automatically.
 
 ### Example: Extra Backup Options
 

--- a/web/docs/misc.md
+++ b/web/docs/misc.md
@@ -41,6 +41,7 @@ configuration.
 - `.spec.configuration.data.additionalCommandArgs`: for `barman-cloud-backup`
 - `.spec.configuration.data.restoreAdditionalCommandArgs`: for `barman-cloud-restore`
 - `.spec.configuration.wal.archiveAdditionalCommandArgs`: for `barman-cloud-wal-archive`
+- `.spec.configuration.wal.restoreAdditionalCommandArgs`: for `barman-cloud-wal-restore`
 
 Each field accepts a list of string arguments. If an argument is already
 configured elsewhere in the plugin, the duplicate will be ignored.
@@ -83,6 +84,19 @@ spec:
     wal:
       archiveAdditionalCommandArgs:
         - "--max-concurrency=1"
+        - "--read-timeout=60"
+```
+
+### Example: Extra WAL Restore Options
+
+```yaml
+kind: ObjectStore
+metadata:
+  name: my-store
+spec:
+  configuration:
+    wal:
+      restoreAdditionalCommandArgs:
         - "--read-timeout=60"
 ```
 

--- a/web/docs/misc.md
+++ b/web/docs/misc.md
@@ -32,13 +32,14 @@ spec:
   [...]
 ```
 
-## Extra Options for Backup and WAL Archiving
+## Extra Options for Backup, WAL Archiving, and Restore
 
-You can pass additional command-line arguments to `barman-cloud-backup` and
-`barman-cloud-wal-archive` using the `additionalCommandArgs` field in the
-`ObjectStore` configuration.
+You can pass additional command-line arguments to the underlying
+`barman-cloud-*` commands using the corresponding fields in the `ObjectStore`
+configuration.
 
 - `.spec.configuration.data.additionalCommandArgs`: for `barman-cloud-backup`
+- `.spec.configuration.data.restoreAdditionalCommandArgs`: for `barman-cloud-restore`
 - `.spec.configuration.wal.archiveAdditionalCommandArgs`: for `barman-cloud-wal-archive`
 
 Each field accepts a list of string arguments. If an argument is already
@@ -56,6 +57,19 @@ spec:
       additionalCommandArgs:
         - "--min-chunk-size=5MB"
         - "--read-timeout=60"
+```
+
+### Example: Extra Restore Options
+
+```yaml
+kind: ObjectStore
+metadata:
+  name: my-store
+spec:
+  configuration:
+    data:
+      restoreAdditionalCommandArgs:
+        - "--read-timeout=900"
 ```
 
 ### Example: Extra WAL Archive Options


### PR DESCRIPTION

  An `ObjectStore` already lets users tack extra command-line flags onto three of the four `barman-cloud-*` invocations: `barman-cloud-backup` via
  `data.additionalCommandArgs`, `barman-cloud-wal-archive` via `wal.archiveAdditionalCommandArgs`, and `barman-cloud-wal-restore` via
  `wal.restoreAdditionalCommandArgs`. The fourth — `barman-cloud-restore`, the actual data-restore step in PITR and recovery-from-object-store — has had no
   equivalent, which is exactly the gap reported in #821 (the asker wanted a longer `--read-timeout` for slow restores from S3).

  This PR fills that gap by adding `spec.configuration.data.restoreAdditionalCommandArgs` and wiring it into the recovery job hook. In `restoreDataDir`,
  the user-supplied flags are appended after the cloud-provider options and `--endpoint-url` but before the positional `(destinationPath, serverName,
  backupID, pgdata)` arguments — same shape as the other three knobs. The library's existing append/dedup logic still wins on conflicts, so users can't
  accidentally override flags the plugin already sets (`--cloud-provider`, `--endpoint-url`, etc.).

  ## Sister PR (must merge first)

  The CRD field is generated from the `BarmanObjectStoreConfiguration` Go type in `cloudnative-pg/barman-cloud`, so the actual API change lives upstream:
  **cloudnative-pg/barman-cloud#242** — which adds `DataBackupConfiguration.RestoreAdditionalCommandArgs` and the `AppendRestoreAdditionalCommandArgs`
  helper. Once that PR merges and a `barman-cloud` release is cut, `controller-gen` here picks up the new field automatically.

  `go.mod` is temporarily pinned to  https://github.com/cloudnative-pg/barman-cloud/pull/242 HEAD commit via a pseudo-version (`v0.5.2-0.20260513095406-dac43abc6cf6`) so CI on this branch can run
  end-to-end against the unreleased upstream change. **This pin must be replaced with a tagged `barman-cloud` release before this PR can merge.**

Closes #821
