### PR TITLE
feat: expose showAdditionalCommandArgs and listAdditionalCommandArgs

### DIFF
--- a/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+++ b/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
@@ -176,6 +176,37 @@ spec:
                         format: int32
                         minimum: 1
                         type: integer
+                      listAdditionalCommandArgs:
+                        description: |-
+                          ListAdditionalCommandArgs represents additional arguments that can be appended
+                          to the 'barman-cloud-backup-list' command-line invocation. This command is
+                          used internally for retention-policy enforcement; flags relevant to the
+                          underlying S3 client (e.g. `--addressing-style=virtual` for strictly
+                          virtual-hosted S3-compatible endpoints) generally belong here as well.
+
+                          Note:
+                          It's essential to ensure that the provided arguments are valid and supported
+                          by the 'barman-cloud-backup-list' command, to avoid potential errors or
+                          unintended behavior during execution.
+                        items:
+                          type: string
+                        type: array
+                      showAdditionalCommandArgs:
+                        description: |-
+                          ShowAdditionalCommandArgs represents additional arguments that can be appended
+                          to the 'barman-cloud-backup-show' command-line invocation. This command is
+                          used after a successful upload to verify and record metadata about the
+                          freshly-written backup, so flags relevant to the underlying S3 client
+                          (e.g. `--addressing-style=virtual` for strictly virtual-hosted S3-compatible
+                          endpoints) generally belong here as well.
+
+                          Note:
+                          It's essential to ensure that the provided arguments are valid and supported
+                          by the 'barman-cloud-backup-show' command, to avoid potential errors or
+                          unintended behavior during execution.
+                        items:
+                          type: string
+                        type: array
                     type: object
                   destinationPath:
                     description: |-

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -175,6 +175,37 @@ spec:
                         format: int32
                         minimum: 1
                         type: integer
+                      listAdditionalCommandArgs:
+                        description: |-
+                          ListAdditionalCommandArgs represents additional arguments that can be appended
+                          to the 'barman-cloud-backup-list' command-line invocation. This command is
+                          used internally for retention-policy enforcement; flags relevant to the
+                          underlying S3 client (e.g. `--addressing-style=virtual` for strictly
+                          virtual-hosted S3-compatible endpoints) generally belong here as well.
+
+                          Note:
+                          It's essential to ensure that the provided arguments are valid and supported
+                          by the 'barman-cloud-backup-list' command, to avoid potential errors or
+                          unintended behavior during execution.
+                        items:
+                          type: string
+                        type: array
+                      showAdditionalCommandArgs:
+                        description: |-
+                          ShowAdditionalCommandArgs represents additional arguments that can be appended
+                          to the 'barman-cloud-backup-show' command-line invocation. This command is
+                          used after a successful upload to verify and record metadata about the
+                          freshly-written backup, so flags relevant to the underlying S3 client
+                          (e.g. `--addressing-style=virtual` for strictly virtual-hosted S3-compatible
+                          endpoints) generally belong here as well.
+
+                          Note:
+                          It's essential to ensure that the provided arguments are valid and supported
+                          by the 'barman-cloud-backup-show' command, to avoid potential errors or
+                          unintended behavior during execution.
+                        items:
+                          type: string
+                        type: array
                     type: object
                   destinationPath:
                     description: |-

--- a/web/docs/misc.md
+++ b/web/docs/misc.md
@@ -32,14 +32,21 @@ spec:
   [...]
 ```
 
-## Extra Options for Backup and WAL Archiving
+## Extra Options for Backup, WAL Archiving, Show, and List
 
-You can pass additional command-line arguments to `barman-cloud-backup` and
-`barman-cloud-wal-archive` using the `additionalCommandArgs` field in the
-`ObjectStore` configuration.
+You can pass additional command-line arguments to each barman-cloud
+invocation the plugin shells out to, using the matching
+`additionalCommandArgs` fields in the `ObjectStore` configuration.
 
 - `.spec.configuration.data.additionalCommandArgs`: for `barman-cloud-backup`
+- `.spec.configuration.data.showAdditionalCommandArgs`: for `barman-cloud-backup-show` (post-write verification)
+- `.spec.configuration.data.listAdditionalCommandArgs`: for `barman-cloud-backup-list` (retention pruning)
 - `.spec.configuration.wal.archiveAdditionalCommandArgs`: for `barman-cloud-wal-archive`
+
+If you need a flag that applies to every cloud command — such as
+`--addressing-style=virtual` for an S3-compatible endpoint that only
+accepts virtual-hosted-style requests — set it on all of the above so
+both writes and the post-write read-back / retention steps honor it.
 
 Each field accepts a list of string arguments. If an argument is already
 configured elsewhere in the plugin, the duplicate will be ignored.


### PR DESCRIPTION
## Summary

An `ObjectStore` already lets users tack extra command-line flags onto four of the six `barman-cloud-*` invocations the plugin shells out to:

| barman command | existing field |
|---|---|
| `barman-cloud-backup` | `data.additionalCommandArgs` |
| `barman-cloud-wal-archive` | `wal.archiveAdditionalCommandArgs` |
| `barman-cloud-wal-restore` | `wal.restoreAdditionalCommandArgs` |
| `barman-cloud-restore` | `data.restoreAdditionalCommandArgs` (#914) |

The remaining two — `barman-cloud-backup-show` (post-write verification) and `barman-cloud-backup-list` (retention pruning) — had no equivalent, which is the gap reported in #712.

This is observable in practice on S3-compatible endpoints that strictly require virtual-hosted-style addressing for LIST. On such backends:

- `barman-cloud-backup` accepts user-provided `--addressing-style=virtual` via the existing `data.additionalCommandArgs` ✅ — base backup completes and lands in the bucket
- `barman-cloud-backup-show` runs immediately afterwards with no way to thread the flag through, sends path-style by default, gets `PathStyleRequestNotAllowed`, exits with status 4
- The plugin marks the otherwise-successful backup as `phase: failed`
- Retention pruning (which goes via `barman-cloud-backup-list`) is similarly broken — old backups silently never get expired

So user-visible Backup CR status is wrong and retention is silently disabled, even though the actual base-backup data is intact in the bucket. The Backup CRs from such clusters look like:

\`\`\`
NAME                                       AGE     METHOD   PHASE    ERROR
my-cluster-db-backup-20260524000000        2d11h   plugin   failed   rpc error: code = Unknown desc = exit status 4
my-cluster-db-backup-20260525000000        35h     plugin   failed   rpc error: code = Unknown desc = exit status 4
\`\`\`

with plugin logs showing:

\`\`\`
{level:info, msg:\"Starting barman-cloud-backup\", options:[..., \"--addressing-style=virtual\", ...]}
{level:info, msg:\"Completed barman-cloud-backup\", ...}
{level:error, logger:\"barman\", msg:\"Can't extract backup id\", command:\"barman-cloud-backup-show\",
 options:[\"--format\",\"json\",\"--endpoint-url\",...,\"--cloud-provider\",\"aws-s3\",\"s3://bucket/path/\",\"server-name\",\"backup-...\"],
 stderr:\"ERROR: Barman cloud backup show exception: An error occurred (PathStyleRequestNotAllowed)\n\"}
\`\`\`

Note the `--addressing-style=virtual` is present on the first invocation but missing on the second.

## Changes

- New CRD fields under `spec.configuration.data`:
  - `showAdditionalCommandArgs` (passed to `barman-cloud-backup-show`)
  - `listAdditionalCommandArgs` (passed to `barman-cloud-backup-list`)
- CRD YAML in `config/crd/bases/barmancloud.cnpg.io_objectstores.yaml` and `manifest.yaml` updated to include the two new array fields
- `web/docs/misc.md` updated to list all four args fields, with a note on the cross-cutting `--addressing-style=virtual` use case

No Go code changes are needed in this repo — the actual plumbing lives in the sister PR against [cloudnative-pg/barman-cloud#249](https://github.com/cloudnative-pg/barman-cloud/pull/249), which adds the matching Go fields, `Append*` helpers, and the call-site changes inside `GetBackupByName` and `GetBackupList`. Once that PR merges and a `barman-cloud` release is cut, bumping `go.mod` here will pick up the new behavior automatically.

## Sister PR (must merge first)

cloudnative-pg/barman-cloud#249

Closes #712
