### PR TITLE
fix: change default log level from debug to info in deployment.yaml

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - --client-cert=/client/tls.crt
         - --server-address=:9090
         - --leader-elect
-        - --log-level=debug
+        - --log-level=info
         readinessProbe:
           tcpSocket:
             port: 9090


### PR DESCRIPTION
## Problem

Part of #917.

`kubernetes/deployment.yaml` has `--log-level=debug` hardcoded. In production clusters with frequent WAL archiving, this generates a high volume of debug-level log entries (`generated patch`, lifecycle reconciliation details) that are not actionable in normal operations and add significant noise to log aggregation systems (Loki, CloudWatch, etc.).

## Fix

Change the hardcoded value from `debug` to `info`, which is the appropriate default for a production operator.

```diff
-        - --log-level=debug
+        - --log-level=info
```

Debug logging remains available by patching the deployment args directly or updating your Kustomize overlay.

## Scope

This PR addresses the global default for the raw Kubernetes manifest. The full scope of #917 (Helm value + per-cluster override via `plugins.parameters`) is deferred as follow-up work.