### PR TITLE
fix(scheme): register meta types for CNPG scheme group version

### DIFF
--- a/internal/cnpgi/common/scheme.go
+++ b/internal/cnpgi/common/scheme.go
@@ -25,6 +25,7 @@ import (
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/viper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -58,6 +59,7 @@ func GenerateScheme(ctx context.Context) *runtime.Scheme {
 		&cnpgv1.Backup{}, &cnpgv1.BackupList{},
 		&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{},
 	)
+	metav1.AddToGroupVersion(result, schemeGroupVersion)
 
 	schemeLog := log.FromContext(ctx)
 	schemeLog.Info("CNPG types registration", "schemeGroupVersion", schemeGroupVersion)

--- a/internal/scheme/cnpg.go
+++ b/internal/scheme/cnpg.go
@@ -25,6 +25,7 @@ import (
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
 	"github.com/cloudnative-pg/machinery/pkg/log"
 	"github.com/spf13/viper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -49,6 +50,7 @@ func AddCNPGToScheme(ctx context.Context, s *runtime.Scheme) {
 		&cnpgv1.Backup{}, &cnpgv1.BackupList{},
 		&cnpgv1.ScheduledBackup{}, &cnpgv1.ScheduledBackupList{},
 	)
+	metav1.AddToGroupVersion(s, schemeGroupVersion)
 
 	log.FromContext(ctx).Info("CNPG types registration", "schemeGroupVersion", schemeGroupVersion)
 }


### PR DESCRIPTION
After the controller-runtime v0.24.0 upgrade (58f4fed), the instance sidecar logged "v1.GetOptions is not suitable for converting to postgresql.cnpg.io/v1" on every WAL archive, which broke retention policy enforcement.

Register the standard meta types with metav1.AddToGroupVersion after the AddKnownTypes call in internal/cnpgi/common/scheme.go and internal/scheme/cnpg.go.

Closes #942