### PR TITLE
chore(deps): drop setuptools dependency

### DIFF
--- a/containers/Dockerfile.sidecar
+++ b/containers/Dockerfile.sidecar
@@ -55,7 +55,7 @@ COPY containers/sidecar-requirements.txt .
 
 # Create virtualenv and install dependencies
 RUN python3 -m venv /venv && \
-    /venv/bin/pip install --upgrade pip setuptools wheel && \
+    /venv/bin/pip install --upgrade pip wheel && \
     /venv/bin/pip install --no-cache-dir -r sidecar-requirements.txt
 
 # Download and extract runtime library packages and their dependencies

--- a/containers/sidecar-requirements.in
+++ b/containers/sidecar-requirements.in
@@ -1,3 +1,2 @@
 barman[azure,cloud,google,snappy,zstandard,lz4]==3.19.1
-setuptools==82.0.1
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/containers/sidecar-requirements.txt
+++ b/containers/sidecar-requirements.txt
@@ -780,9 +780,3 @@ zstandard==0.25.0 \
     --hash=sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551 \
     --hash=sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01
     # via barman
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==82.0.1 \
-    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
-    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
-    # via -r sidecar-requirements.in


### PR DESCRIPTION
Barman 3.19 dropped its runtime dependency on setuptools, so we no longer need to pin it in the sidecar requirements or install it in the image build. A Python 3.13 venv no longer seeds setuptools by default, so removing it from the pip upgrade keeps it out of the runtime image entirely.