### PR TITLE
docs: installation using the helm chart

### DIFF
--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -57,7 +57,7 @@ Both checks are required before proceeding with the installation.
 import { InstallationSnippet } from '@site/src/components/Installation';
 
 Install the plugin using `kubectl` by applying the manifest for the latest
-release:
+release or using the Helm chart:
 
 <InstallationSnippet />
 

--- a/web/docs/troubleshooting.md
+++ b/web/docs/troubleshooting.md
@@ -485,14 +485,10 @@ If problems persist:
 
 ### Plugin Limitations
 
-1. **Installation method**: Currently only supports manifest and Kustomize
-   installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) -
-   Helm chart requested)
-
-2. **Sidecar resource sharing**: The plugin sidecar container shares pod
+1. **Sidecar resource sharing**: The plugin sidecar container shares pod
    resources with PostgreSQL
 
-3. **Plugin restart behavior**: Restarting the sidecar container requires
+2. **Plugin restart behavior**: Restarting the sidecar container requires
    restarting the entire PostgreSQL pod
 
 ## Recap of General Debugging Steps
@@ -588,4 +584,3 @@ kubectl get secret -n <namespace> <secret-name> -o jsonpath='{.data}' | jq 'keys
 * **"NoSuchBucket"** — Verify the bucket exists and the endpoint URL is correct.
 * **"Connection timeout"** — Check network connectivity and firewall rules.
 * **"SSL certificate problem"** — For self-signed certificates, verify the CA bundle configuration.
-

--- a/web/src/components/Installation/index.tsx
+++ b/web/src/components/Installation/index.tsx
@@ -1,16 +1,31 @@
 import {ReactElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import {useCurrentVersion} from '@site/src/hooks/versions';
+import {MultiLangCodeBlock} from '@site/src/components/MultiLangCodeBlock';
 
 // InstallationSnippet is the kubectl incantation to install the lastest
 // available version of the Barman Cloud Plugin.
 export function InstallationSnippet(): ReactElement<null> {
     const latest = useCurrentVersion('latestReleased');
-    return (
-        <CodeBlock language="sh">
-            {`kubectl apply -f \\
-        https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v${latest}/manifest.yaml`}
-        </CodeBlock>
-    );
-}
 
+    const snippets = [
+      {
+        label: 'kubectl',
+        language: 'sh',
+        code: `kubectl apply -f \\
+https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v${latest}/manifest.yaml`,
+      },
+      {
+        label: 'Helm',
+        language: 'sh',
+        code: `helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+helm upgrade \\
+  --install \\
+  --namespace cnpg-system \\
+  plugin-barman-cloud cnpg/plugin-barman-cloud`,
+      },
+    ];
+
+    return <MultiLangCodeBlock snippets={snippets} />;
+}

--- a/web/src/components/MultiLangCodeBlock/index.tsx
+++ b/web/src/components/MultiLangCodeBlock/index.tsx
@@ -1,0 +1,79 @@
+import React, {ReactElement, useState} from 'react';
+import CodeBlock from '@theme/CodeBlock';
+
+export type Snippet = {
+  label: string;      // visible tab label (e.g. "Shell", "Helm", "Go")
+  language: string;   // language prop for CodeBlock (e.g. "sh", "yaml", "go")
+  code: string;       // the snippet to display
+};
+
+type Props = {
+  snippets: Snippet[];
+  defaultIndex?: number;
+  className?: string;
+};
+
+export function MultiLangCodeBlock({snippets, defaultIndex = 0, className}: Props): ReactElement | null {
+  const safeDefault = Math.max(0, Math.min(defaultIndex, snippets.length - 1));
+  const [active, setActive] = useState<number>(snippets.length > 0 ? safeDefault : -1);
+
+  if (snippets.length === 0) return null;
+
+  const tabStyle: React.CSSProperties = {
+    padding: '0.3rem 0.5rem',
+    cursor: 'pointer',
+    border: '0',
+    borderRadius: 'var(--ifm-code-border-radius)',
+    margin: '0 0 0 0',
+    fontSize: '0.8125rem',
+    color: 'inherit',
+  };
+
+  const activeTabStyle: React.CSSProperties = {
+    ...tabStyle,
+    fontWeight: 700,
+  };
+
+  const tabsContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+    gap: '0.25rem',
+    margin: '0 0 -0.5rem',
+    padding: '0.5rem 0.5rem 1rem',
+    flexWrap: 'wrap',
+  };
+
+  const wrapperStyle: React.CSSProperties = {
+    overflow: 'hidden',
+    padding: '0',
+  };
+
+  return (
+    <div className={className} style={wrapperStyle}>
+      <div role="tablist" aria-label="Code snippets" style={tabsContainerStyle}>
+        {snippets.map((ex, idx) => (
+          <button
+            key={ex.label + idx}
+            role="tab"
+            aria-selected={active === idx}
+            aria-controls={`code-panel-${idx}`}
+            id={`code-tab-${idx}`}
+            onClick={() => setActive(idx)}
+            style={active === idx ? activeTabStyle : tabStyle}
+          >
+            {ex.label}
+          </button>
+        ))}
+      </div>
+
+      <div role="tabpanel" id={`code-panel-${active}`} aria-labelledby={`code-tab-${active}`}>
+        <CodeBlock language={snippets[active].language}>
+{snippets[active].code}
+        </CodeBlock>
+      </div>
+    </div>
+  );
+}
+
+export default MultiLangCodeBlock;

--- a/web/versioned_docs/version-0.13.0/installation.mdx
+++ b/web/versioned_docs/version-0.13.0/installation.mdx
@@ -57,7 +57,7 @@ Both checks are required before proceeding with the installation.
 import { InstallationSnippet } from '@site/src/components/Installation';
 
 Install the plugin using `kubectl` by applying the manifest for the latest
-release:
+release or using the Helm chart:
 
 <InstallationSnippet />
 

--- a/web/versioned_docs/version-0.13.0/troubleshooting.md
+++ b/web/versioned_docs/version-0.13.0/troubleshooting.md
@@ -485,14 +485,10 @@ If problems persist:
 
 ### Plugin Limitations
 
-1. **Installation method**: Currently only supports manifest and Kustomize
-   installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) -
-   Helm chart requested)
-
-2. **Sidecar resource sharing**: The plugin sidecar container shares pod
+1. **Sidecar resource sharing**: The plugin sidecar container shares pod
    resources with PostgreSQL
 
-3. **Plugin restart behavior**: Restarting the sidecar container requires
+2. **Plugin restart behavior**: Restarting the sidecar container requires
    restarting the entire PostgreSQL pod
 
 ## Recap of General Debugging Steps
@@ -588,4 +584,3 @@ kubectl get secret -n <namespace> <secret-name> -o jsonpath='{.data}' | jq 'keys
 * **"NoSuchBucket"** — Verify the bucket exists and the endpoint URL is correct.
 * **"Connection timeout"** — Check network connectivity and firewall rules.
 * **"SSL certificate problem"** — For self-signed certificates, verify the CA bundle configuration.
-


### PR DESCRIPTION
I may have over-complicated the addition of an extra CLI example, but it looks so much better this way.

The PR adds documentation for installing the plugin through the helm chart and removes the following limitation note:

> Installation method: Currently only supports manifest and Kustomize installation ([#351](https://github.com/cloudnative-pg/plugin-barman-cloud/issues/351) - Helm chart requested)

<img width="801" height="358" alt="Screenshot From 2026-06-29 02-26-51" src="https://github.com/user-attachments/assets/618a279c-0303-49e3-a2e3-0de93490845e" />

While we've had a Helm chart since `v0.5.0` we've done a lot of modifications and fixes to it so 
I added the documentation changes to the primary documents and the `v0.13` documents only.

P.S. The kubectl manifest example is still first and the default one.

Closes #351 