### PR TITLE
fix: reduce startupProbe periodSeconds without losing failure tolerance

### DIFF
--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -403,6 +403,7 @@ func reconcilePodSpec(
 	envs = append(envs, config.env...)
 
 	baseProbe := &corev1.Probe{
+		PeriodSeconds:    1,
 		FailureThreshold: 10,
 		TimeoutSeconds:   10,
 		ProbeHandler: corev1.ProbeHandler{

--- a/internal/cnpgi/operator/lifecycle.go
+++ b/internal/cnpgi/operator/lifecycle.go
@@ -404,8 +404,8 @@ func reconcilePodSpec(
 
 	baseProbe := &corev1.Probe{
 		PeriodSeconds:    1,
-		FailureThreshold: 10,
-		TimeoutSeconds:   10,
+		FailureThreshold: 30,
+		TimeoutSeconds:   5,
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{"/manager", "healthcheck", "unix"},


### PR DESCRIPTION
The startup probe for the injected plugin-barman-cloud sidecar previously left `periodSeconds` unset, so the API server defaulted it to 10s. Because the sidecar is a native init container that gates the main postgres container on reaching `Started`, this added roughly one full period to every pod's startup, even though the probe itself (a local unix-socket health check) normally succeeds in milliseconds.

`periodSeconds` is now 1s, so the probe reports success almost immediately in the common case. To avoid trading away failure tolerance for that faster common case, `failureThreshold` is raised to 30 and `timeoutSeconds` is lowered to 5s: a unix-socket call essentially never times out under mere load, so hitting the timeout means the sidecar is genuinely unresponsive rather than just slow, and it's fine to give that rare case more attempts before restarting the container.

Closes #991