### PR TITLE
chore(renovate): stop ignoring test/e2e/internal/tests/**

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,14 +12,14 @@
   rebaseWhen: 'never',
   prConcurrentLimit: 5,
   // Override default ignorePaths to scan test/e2e for emulator image dependencies
-  // Removed: '**/test/**'
+  // Removed: '**/test/**', '**/tests/**' (this repo's e2e Ginkgo packages live
+  // under test/e2e/internal/tests/**, which the plural pattern was excluding)
   ignorePaths: [
     '**/node_modules/**',
     '**/bower_components/**',
     '**/vendor/**',
     '**/examples/**',
     '**/__tests__/**',
-    '**/tests/**',
     '**/__fixtures__/**',
   ],
   lockFileMaintenance: {


### PR DESCRIPTION
ignorePaths still had '**/tests/**' left over from the recommended preset, even though a comment right above documents removing '**/test/**' specifically to let renovate scan test/e2e for emulator image dependencies. Every e2e Ginkgo package lives under test/e2e/internal/tests/**, so the plural pattern was silently excluding all of them; any image pinned by digest in those packages (e.g. minio, aws-cli) was never going to get a bump PR.

No other tracked path in the repo matches '**/tests/**' once node_modules is excluded by its own rule, so this narrows nothing else.