### PR TITLE
fix(docs): fix broken anchor link in concepts.md

### DIFF
--- a/web/docs/concepts.md
+++ b/web/docs/concepts.md
@@ -43,7 +43,7 @@ as **tarballs** in the `base` directory, following the
 
 The plugin also offers advanced capabilities, including
 [backup tagging](misc.md#backup-object-tagging) and
-[extra options for backups and WAL archiving](misc.md#extra-options-for-backup-and-wal-archiving).
+[extra options for backups and WAL archiving](misc.md#extra-options-for-backup-wal-archiving-and-restore).
 
 :::tip
 For details, refer to the

--- a/web/docusaurus.config.ts
+++ b/web/docusaurus.config.ts
@@ -21,7 +21,12 @@ const config: Config = {
   deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
   },
   "resolutions": {
     "webpackbar": "^7.0.0",
-    "serialize-javascript": ">=7.0.5"
+    "serialize-javascript": ">=7.0.5",
+    "uuid": ">=11.1.1"
   }
 }

--- a/web/versioned_docs/version-0.13.0/concepts.md
+++ b/web/versioned_docs/version-0.13.0/concepts.md
@@ -43,7 +43,7 @@ as **tarballs** in the `base` directory, following the
 
 The plugin also offers advanced capabilities, including
 [backup tagging](misc.md#backup-object-tagging) and
-[extra options for backups and WAL archiving](misc.md#extra-options-for-backup-and-wal-archiving).
+[extra options for backups and WAL archiving](misc.md#extra-options-for-backup-wal-archiving-and-restore).
 
 :::tip
 For details, refer to the

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -9215,10 +9215,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@>=11.1.1, uuid@^8.3.2:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.1.tgz#8a5975b3e038902bfd169a10b5202f5ec0cf3faf"
+  integrity sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The heading in misc.md was renamed to "Extra Options for Backup, WAL Archiving, and Restore", which changed its anchor slug, but the link in concepts.md still pointed at the old anchor. Update the link in both the current docs and the affected 0.13.0 versioned snapshot.

Also migrate the deprecated onBrokenMarkdownLinks config option to markdown.hooks.onBrokenMarkdownLinks, since it will be removed in Docusaurus v4, and bump the transitive uuid dependency pulled in via docusaurus/core, docusaurus/preset-classic, and docusaurus-search-local to a patched version to fix an alert for CVE-2026-41907.

Docusaurus build now completes with no warnings.