### PR TITLE
ci: make runner labels configurable via CI_RUNNERS variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Cleanup Disk
+        if: vars.CI_RUNNERS == '' || vars.CI_RUNNERS == 'ubuntu-latest'
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           android: true
@@ -23,6 +24,7 @@ jobs:
           large-packages: false
           swap-storage: false
       - name: Cleanup docker cache
+        if: vars.CI_RUNNERS == '' || vars.CI_RUNNERS == 'ubuntu-latest'
         run: |
           echo "-------------Disk info before cleanup----------------"
           df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     permissions:
       packages: write
       contents: write

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -20,7 +20,7 @@ permissions: read-all
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -60,7 +60,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,7 +9,7 @@ permissions: read-all
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -7,7 +7,7 @@ permissions: read-all
 
 jobs:
   release-publish-artifacts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     permissions:
       packages: write
       contents: write


### PR DESCRIPTION
Switch all workflow jobs from a hardcoded ubuntu-latest to ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}, so runner sizing can be changed via the CI_RUNNERS organization/repository variable without editing workflow files.

The cloudnative-pg organization CI_RUNNERS variable is already set to ubuntu-latest-16-cores.