### PR TITLE
ci: run image publish in a separate parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
   ci:
     runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
     permissions:
-      packages: write
-      contents: write
+      contents: read
     steps:
       - name: Cleanup Disk
         if: vars.CI_RUNNERS == '' || vars.CI_RUNNERS == 'ubuntu-latest'
@@ -39,8 +38,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install QEMU static binaries
-        uses: docker/setup-qemu-action@v4
       - name: Install Task
         uses: arduino/setup-task@v3.0.0
       - name: Install Dagger
@@ -52,6 +49,27 @@ jobs:
       - name: Run CI task
         run: |
           task ci
+
+  publish:
+    runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install QEMU static binaries
+        uses: docker/setup-qemu-action@v4
+      - name: Install Task
+        uses: arduino/setup-task@v3.0.0
+      - name: Install Dagger
+        env:
+          # renovate: datasource=github-tags depName=dagger/dagger versioning=semver
+          DAGGER_VERSION: 0.21.7
+        run: |
+          curl -L https://dl.dagger.io/dagger/install.sh | BIN_DIR=$HOME/.local/bin sh
       - name: Write manifest
         run: |
           task manifest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     runs-on: ${{ vars.CI_RUNNERS || 'ubuntu-latest' }}


### PR DESCRIPTION
Neither task depends on the other's output: task ci runs lint, tests, e2e, and docs, while task publish builds and pushes the multi-arch images. Running them as sequential steps in one job only adds their durations. Splitting publish into its own job lets it run alongside ci instead, and lets each job carry only the permissions it actually needs: ci never writes to the registry, and neither task touches repository contents, so only packages: write on the publish job remains.

QEMU is only needed for publish, since it's the only job that builds non-native (arm64) platforms; ci's e2e-ephemeral image build is amd64-only. The disk cleanup steps aren't needed for publish either: it only builds two lean multi-arch images, well within the free disk space available even on the default ubuntu-latest runner.

Note that publishing testing images no longer waits on ci passing, since gating it away would remove the parallelism this is meant to gain.

Note: main's required status checks are currently ["DCO", "ci"]. A failure in the new publish job will no longer block merging a PR, since it isn't in that list (today it does, since publishing is a step inside the required ci job). Flagging for a decision on whether publish should be added as a required check.