### PR TITLE
docs: add helm installation steps

### DIFF
--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -54,6 +54,8 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
+### Using manifest
+
 import { InstallationSnippet } from '@site/src/components/Installation';
 
 Install the plugin using `kubectl` by applying the manifest for the latest
@@ -82,6 +84,20 @@ certificate.cert-manager.io/barman-cloud-client created
 certificate.cert-manager.io/barman-cloud-server created
 issuer.cert-manager.io/selfsigned-issuer created
 ```
+
+### Using helm
+
+Install the plugin [helm chart](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud) using `helm`:
+
+```sh
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm repo update
+helm upgrade --install plugin-barman-cloud \
+  --namespace cnpg-system \
+  cnpg/plugin-barman-cloud
+```
+
+### Validating the installation
 
 Finally, check that the deployment is up and running:
 


### PR DESCRIPTION
## Issue

The barman cloud plugin helm chart docs [include installation steps](https://github.com/cloudnative-pg/charts/tree/main/charts/plugin-barman-cloud), but the [barman cloud website](https://cloudnative-pg.io/plugin-barman-cloud/docs/installation/) does not mention the barman cloud helm chart at all

## Change

Added helm installation steps to the barman cloud website