### PR TITLE
fix: honour the object store requested by a Backup resource

### DIFF
--- a/internal/cnpgi/instance/backup.go
+++ b/internal/cnpgi/instance/backup.go
@@ -81,6 +81,8 @@ func (b BackupServiceImplementation) Backup(
 		return nil, err
 	}
 
+	configuration.ApplyBackupParameters(request.GetParameters())
+
 	var objectStore barmancloudv1.ObjectStore
 	if err := b.Client.Get(ctx, configuration.GetBarmanObjectKey(), &objectStore); err != nil {
 		contextLogger.Error(err, "while getting object store", "key", configuration.GetRecoveryBarmanObjectKey())

--- a/internal/cnpgi/operator/config/config.go
+++ b/internal/cnpgi/operator/config/config.go
@@ -76,6 +76,12 @@ type PluginConfiguration struct {
 
 	ReplicaSourceBarmanObjectName string
 	ReplicaSourceServerName       string
+
+	// AdditionalBarmanObjectNames lists the object stores that a Backup
+	// resource is allowed to request on top of the ones used by the cluster
+	// itself. Nothing is written to them unless a Backup asks for one, but
+	// they take part in the RBAC and in the certificates of the instances.
+	AdditionalBarmanObjectNames []string
 }
 
 // GetBarmanObjectKey gets the namespaced name of the barman object
@@ -133,8 +139,11 @@ func (config *PluginConfiguration) GetReferredBarmanObjectsKey() []types.Namespa
 	if len(config.ReplicaSourceBarmanObjectName) > 0 {
 		objectNames.Put(config.ReplicaSourceBarmanObjectName)
 	}
+	for _, name := range config.AdditionalBarmanObjectNames {
+		objectNames.Put(name)
+	}
 
-	result := make([]types.NamespacedName, 0, 3)
+	result := make([]types.NamespacedName, 0, 4)
 	for _, name := range objectNames.ToSortedList() {
 		result = append(result, types.NamespacedName{
 			Name:      name,
@@ -197,12 +206,31 @@ func NewFromCluster(cluster *cnpgv1.Cluster) *PluginConfiguration {
 		// used for the backup/archive
 		BarmanObjectName: helper.Parameters["barmanObjectName"],
 		ServerName:       serverName,
+		// reachable by a Backup resource requesting them explicitly
+		AdditionalBarmanObjectNames: parseObjectNameList(helper.Parameters["additionalBarmanObjectNames"]),
 		// used for restore and wal_restore during backup recovery
 		RecoveryServerName:       recoveryServerName,
 		RecoveryBarmanObjectName: recoveryBarmanObjectName,
 		// used for wal_restore in the designed primary of a replica cluster
 		ReplicaSourceServerName:       replicaSourceServerName,
 		ReplicaSourceBarmanObjectName: replicaSourceBarmanObjectName,
+	}
+
+	return result
+}
+
+// parseObjectNameList splits a comma separated list of object store names,
+// dropping the empty entries
+func parseObjectNameList(value string) []string {
+	if len(value) == 0 {
+		return nil
+	}
+
+	var result []string
+	for _, name := range strings.Split(value, ",") {
+		if name = strings.TrimSpace(name); len(name) > 0 {
+			result = append(result, name)
+		}
 	}
 
 	return result

--- a/internal/cnpgi/operator/config/config.go
+++ b/internal/cnpgi/operator/config/config.go
@@ -86,6 +86,24 @@ func (config *PluginConfiguration) GetBarmanObjectKey() types.NamespacedName {
 	}
 }
 
+// ApplyBackupParameters overrides the object store selection with the
+// parameters of the Backup resource. The operator relays them in the
+// BackupRequest, and without this a Backup asking for a different object
+// store is silently written to the cluster one.
+func (config *PluginConfiguration) ApplyBackupParameters(parameters map[string]string) {
+	if len(parameters) == 0 {
+		return
+	}
+
+	if value := parameters["barmanObjectName"]; len(value) > 0 {
+		config.BarmanObjectName = value
+	}
+
+	if value := parameters["serverName"]; len(value) > 0 {
+		config.ServerName = value
+	}
+}
+
 // GetRecoveryBarmanObjectKey gets the namespaced name of the recovery barman object
 func (config *PluginConfiguration) GetRecoveryBarmanObjectKey() types.NamespacedName {
 	return types.NamespacedName{

--- a/internal/cnpgi/operator/config/config_test.go
+++ b/internal/cnpgi/operator/config/config_test.go
@@ -163,3 +163,40 @@ var _ = Describe("PluginConfiguration.ApplyBackupParameters", func() {
 		Expect(cfg.ServerName).To(Equal("cluster-example"))
 	})
 })
+
+var _ = Describe("Additional object stores", func() {
+	newConfiguration := func(parameters map[string]string) *PluginConfiguration {
+		return NewFromCluster(&cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "test-ns"},
+			Spec: cnpgv1.ClusterSpec{
+				Plugins: []cnpgv1.PluginConfiguration{
+					{Name: metadata.PluginName, Parameters: parameters},
+				},
+			},
+		})
+	}
+
+	It("are referred to, so that they are covered by RBAC and certificates", func() {
+		cfg := newConfiguration(map[string]string{
+			"barmanObjectName":            "minio-store",
+			"additionalBarmanObjectNames": "archive-store, monthly-store ,",
+		})
+
+		names := make([]string, 0, 3)
+		for _, key := range cfg.GetReferredBarmanObjectsKey() {
+			Expect(key.Namespace).To(Equal("test-ns"))
+			names = append(names, key.Name)
+		}
+
+		Expect(names).To(ConsistOf("minio-store", "archive-store", "monthly-store"))
+	})
+
+	It("do not receive anything on their own", func() {
+		cfg := newConfiguration(map[string]string{
+			"barmanObjectName":            "minio-store",
+			"additionalBarmanObjectNames": "archive-store",
+		})
+
+		Expect(cfg.GetBarmanObjectKey().Name).To(Equal("minio-store"))
+	})
+})

--- a/internal/cnpgi/operator/config/config_test.go
+++ b/internal/cnpgi/operator/config/config_test.go
@@ -124,3 +124,42 @@ var _ = Describe("NewFromCluster", func() {
 		Expect(cfg.Validate()).NotTo(Succeed())
 	})
 })
+
+var _ = Describe("PluginConfiguration.ApplyBackupParameters", func() {
+	newConfiguration := func(parameters map[string]string) *PluginConfiguration {
+		return NewFromCluster(&cnpgv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-example", Namespace: "test-ns"},
+			Spec: cnpgv1.ClusterSpec{
+				Plugins: []cnpgv1.PluginConfiguration{
+					{Name: metadata.PluginName, Parameters: parameters},
+				},
+			},
+		})
+	}
+
+	It("sends the backup to the object store requested by the Backup resource", func() {
+		cfg := newConfiguration(map[string]string{"barmanObjectName": "minio-store"})
+
+		cfg.ApplyBackupParameters(map[string]string{"barmanObjectName": "archive-store"})
+
+		Expect(cfg.GetBarmanObjectKey().Name).To(Equal("archive-store"))
+	})
+
+	It("overrides the server name too", func() {
+		cfg := newConfiguration(map[string]string{"barmanObjectName": "minio-store"})
+
+		cfg.ApplyBackupParameters(map[string]string{"serverName": "another-name"})
+
+		Expect(cfg.ServerName).To(Equal("another-name"))
+		Expect(cfg.GetBarmanObjectKey().Name).To(Equal("minio-store"))
+	})
+
+	It("keeps the cluster object store when the Backup carries no parameters", func() {
+		cfg := newConfiguration(map[string]string{"barmanObjectName": "minio-store"})
+
+		cfg.ApplyBackupParameters(nil)
+
+		Expect(cfg.GetBarmanObjectKey().Name).To(Equal("minio-store"))
+		Expect(cfg.ServerName).To(Equal("cluster-example"))
+	})
+})


### PR DESCRIPTION
Closes #611

### Problem

The operator relays the parameters of a `Backup` resource to the plugin in the `BackupRequest`
(`pkg/management/postgres/webserver/plugin_backup.go` -> `internal/cnpi/plugin/client/backup.go`), but
`BackupServiceImplementation.Backup` builds its configuration from the `Cluster` alone and never reads
`request.Parameters`. A `Backup` asking for a different object store is written to the cluster one, and it ends
up `completed` with no warning: the only symptom is an archive that stays empty.

### What this does

First commit applies the parameters of the `Backup` on top of the configuration derived from the `Cluster`, so
that `barmanObjectName` and `serverName` select the destination of that single backup. A `Backup` without
parameters behaves exactly as before.

Second commit adds the `additionalBarmanObjectNames` cluster level parameter. It is needed to make the first one
usable: the `Role` bound to the instance service account is built from the object stores the `Cluster` refers to,
so a `Backup` naming any other store fails with `objectstores.barmancloud.cnpg.io "..." is forbidden`. The
parameter is a comma separated list of stores that take part in the RBAC and in the certificates of the
instances, while nothing is routed to them.

```yaml
# Cluster
plugins:
  - name: barman-cloud.cloudnative-pg.io
    isWALArchiver: true
    parameters:
      barmanObjectName: minio-store
      additionalBarmanObjectNames: archive-store
---
# Backup
spec:
  method: plugin
  cluster:
    name: cluster-example
  pluginConfiguration:
    name: barman-cloud.cloudnative-pg.io
    parameters:
      barmanObjectName: archive-store

The two commits are separate on purpose: if you would rather widen the Role some other way, the first one stands
on its own.

Testing

Unit tests are added to the existing Ginkgo suite in internal/cnpgi/operator/config.

Verified on a stand with CNPG 1.30.0 and an S3 backend: a Backup requesting archive-store lands in that
store while WALs keep going to the cluster store, the cluster store is left untouched, and a cluster
bootstrapped from that pair comes up with all the data. Without the second commit the same Backup fails with
the forbidden error above.