### PR TITLE
review: adapt installation page text and dev-snapshot section to the docs version

### DIFF
--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -97,6 +97,8 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
+## Testing the latest development snapshot
+
 import { DevSnapshotSection } from '@site/src/components/Installation';
 
 <DevSnapshotSection />

--- a/web/docs/installation.mdx
+++ b/web/docs/installation.mdx
@@ -54,10 +54,9 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
-import { InstallationSnippet } from '@site/src/components/Installation';
+import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
 
-Install the plugin using `kubectl` by applying the manifest for the latest
-release:
+Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
 <InstallationSnippet />
 
@@ -98,12 +97,6 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
-## Testing the latest development snapshot
+import { DevSnapshotSection } from '@site/src/components/Installation';
 
-You can also test the latest development snapshot of the plugin with the
-following command:
-
-```sh
-kubectl apply -f \
-  https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml
-```
+<DevSnapshotSection />

--- a/web/src/components/Installation/index.tsx
+++ b/web/src/components/Installation/index.tsx
@@ -1,6 +1,7 @@
 import {ReactElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
+import Heading from '@theme/Heading';
 
 // InstallationSnippet is the kubectl incantation to install the Barman
 // Cloud Plugin: the manifest matching the doc version being viewed, or
@@ -15,5 +16,34 @@ export function InstallationSnippet(): ReactElement<null> {
             {`kubectl apply -f \\
         ${url}`}
         </CodeBlock>
+    );
+}
+
+// ManifestVersion names the manifest the snippet below installs: the
+// release tag for a versioned docs page, or the main branch on Dev docs.
+export function ManifestVersion(): ReactElement<null> {
+    const activeVersion = useActiveVersion('default');
+    return activeVersion && activeVersion.name !== 'current'
+        ? <>version <code>v{activeVersion.name}</code></>
+        : <>the latest development snapshot from the <code>main</code> branch</>;
+}
+
+
+// DevSnapshotSection offers the main-branch manifest as an alternative;
+// on the Dev docs the main install already is that manifest, so hide it.
+export function DevSnapshotSection(): ReactElement<null> | null {
+    const activeVersion = useActiveVersion('default');
+    const url = 'https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml';
+    if (!activeVersion || activeVersion.name === 'current') return null;
+    return (
+        <>
+            <Heading as="h2" id="testing-the-latest-development-snapshot">
+                Testing the latest development snapshot
+            </Heading>
+            <CodeBlock language="sh">
+                {`kubectl apply -f \\
+        ${url}`}
+            </CodeBlock>
+        </>
     );
 }

--- a/web/src/components/Installation/index.tsx
+++ b/web/src/components/Installation/index.tsx
@@ -1,7 +1,10 @@
 import {ReactElement} from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import {useActiveVersion} from '@docusaurus/plugin-content-docs/client';
-import Heading from '@theme/Heading';
+
+// DEV_MANIFEST_URL is the URL of the manifest.yaml on the main branch of the plugin repo.
+const DEV_MANIFEST_URL =
+    'https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml';
 
 // InstallationSnippet is the kubectl incantation to install the Barman
 // Cloud Plugin: the manifest matching the doc version being viewed, or
@@ -10,7 +13,7 @@ export function InstallationSnippet(): ReactElement<null> {
     const activeVersion = useActiveVersion('default');
     const url = activeVersion && activeVersion.name !== 'current'
         ? `https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v${activeVersion.name}/manifest.yaml`
-        : 'https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml';
+        : DEV_MANIFEST_URL;
     return (
         <CodeBlock language="sh">
             {`kubectl apply -f \\
@@ -24,25 +27,28 @@ export function InstallationSnippet(): ReactElement<null> {
 export function ManifestVersion(): ReactElement<null> {
     const activeVersion = useActiveVersion('default');
     return activeVersion && activeVersion.name !== 'current'
-        ? <>version <code>v{activeVersion.name}</code></>
+        ? <code>v{activeVersion.name}</code>
         : <>the latest development snapshot from the <code>main</code> branch</>;
 }
 
-
 // DevSnapshotSection offers the main-branch manifest as an alternative;
 // on the Dev docs the main install already is that manifest, so hide it.
-export function DevSnapshotSection(): ReactElement<null> | null {
+export function DevSnapshotSection(): ReactElement {
     const activeVersion = useActiveVersion('default');
-    const url = 'https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml';
-    if (!activeVersion || activeVersion.name === 'current') return null;
+    if (!activeVersion || activeVersion.name === 'current') {
+        return (
+            <p>The <a href="#installing-the-barman-cloud-plugin">install
+                command above</a> already applies the latest development
+                snapshot from the <code>main</code> branch.</p>
+        );
+    }
     return (
         <>
-            <Heading as="h2" id="testing-the-latest-development-snapshot">
-                Testing the latest development snapshot
-            </Heading>
+            <p>You can also test the latest development snapshot of the plugin
+                with the following command:</p>
             <CodeBlock language="sh">
                 {`kubectl apply -f \\
-        ${url}`}
+        ${DEV_MANIFEST_URL}`}
             </CodeBlock>
         </>
     );

--- a/web/versioned_docs/version-0.13.0/installation.mdx
+++ b/web/versioned_docs/version-0.13.0/installation.mdx
@@ -97,6 +97,8 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
+## Testing the latest development snapshot
+
 import { DevSnapshotSection } from '@site/src/components/Installation';
 
 <DevSnapshotSection />

--- a/web/versioned_docs/version-0.13.0/installation.mdx
+++ b/web/versioned_docs/version-0.13.0/installation.mdx
@@ -54,10 +54,9 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
-import { InstallationSnippet } from '@site/src/components/Installation';
+import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
 
-Install the plugin using `kubectl` by applying the manifest for the latest
-release:
+Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
 <InstallationSnippet />
 
@@ -98,12 +97,6 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
-## Testing the latest development snapshot
+import { DevSnapshotSection } from '@site/src/components/Installation';
 
-You can also test the latest development snapshot of the plugin with the
-following command:
-
-```sh
-kubectl apply -f \
-  https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml
-```
+<DevSnapshotSection />

--- a/web/versioned_docs/version-0.14.0/installation.mdx
+++ b/web/versioned_docs/version-0.14.0/installation.mdx
@@ -97,6 +97,8 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
+## Testing the latest development snapshot
+
 import { DevSnapshotSection } from '@site/src/components/Installation';
 
 <DevSnapshotSection />

--- a/web/versioned_docs/version-0.14.0/installation.mdx
+++ b/web/versioned_docs/version-0.14.0/installation.mdx
@@ -54,10 +54,9 @@ Both checks are required before proceeding with the installation.
 
 ## Installing the Barman Cloud Plugin
 
-import { InstallationSnippet } from '@site/src/components/Installation';
+import { InstallationSnippet, ManifestVersion } from '@site/src/components/Installation';
 
-Install the plugin using `kubectl` by applying the manifest for the latest
-release:
+Install the plugin using `kubectl` by applying the manifest for <ManifestVersion />:
 
 <InstallationSnippet />
 
@@ -98,12 +97,6 @@ deployment "barman-cloud" successfully rolled out
 
 This confirms that the plugin is deployed and ready to use.
 
-## Testing the latest development snapshot
+import { DevSnapshotSection } from '@site/src/components/Installation';
 
-You can also test the latest development snapshot of the plugin with the
-following command:
-
-```sh
-kubectl apply -f \
-  https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/refs/heads/main/manifest.yaml
-```
+<DevSnapshotSection />


### PR DESCRIPTION
This is add the dev snapshot installion method to versioned doc only since we already use the same manifest in dev.
Also adds version to the doc where we state "Install the plugin using `kubectl` by applying the manifest for the latest"
Since Latest is copied every where I have aligned it.
<img width="924" height="381" alt="Screenshot 2026-08-26 at 6 34 21 PM" src="https://github.com/user-attachments/assets/4b93e5ac-f31f-41eb-9a65-73d0fd8d5707" />


Signed-off-by: danishedb <danish.khan@enterprisedb.com>