### PR TITLE
ci: avoid race in wordlist-ordered task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -34,6 +34,7 @@ tasks:
 
   wordlist-ordered:
     desc: Order the word list file
+    run: once
     cmds:
       - LANG=C LC_ALL=C sort .wordlist.txt > .wordlist.txt.new
       - mv -f .wordlist.txt.new .wordlist.txt


### PR DESCRIPTION
wordlist-ordered is a dep of both spellcheck and uncommitted, which run in parallel. go-task only writes the checksum after a task's cmds finish, so both parents could start the task concurrently: the first mv succeeded and removed .wordlist.txt.new before the second mv ran, failing CI with "No such file or directory".

Mark the task run: once so concurrent deps are deduped.